### PR TITLE
Version 2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "resume-makinator",
   "private": true,
-  "version": "2.2.0",
+  "version": "2.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/entities/resume/lib/importExport.ts
+++ b/src/entities/resume/lib/importExport.ts
@@ -1,0 +1,47 @@
+import type { ResumeData, ResumeImportData } from "@/entities/resume/types"
+
+export const createResumeImportData = (data: ResumeData): ResumeImportData => ({
+    activePage: data.activePage,
+    personalDetails: {
+        ...data.personalDetails,
+        knownLanguages: [...data.personalDetails.knownLanguages],
+    },
+    education: data.education.map(item => ({ ...item })),
+    references: data.references.map(item => ({ ...item })),
+    softSkills: [...data.softSkills],
+    coreSkills: data.coreSkills.map(item => ({
+        ...item,
+        devFramework: [...item.devFramework],
+    })),
+    workExperiences: data.workExperiences.map(item => ({
+        ...item,
+        bulletSummary: [...item.bulletSummary],
+    })),
+    personalProjects: data.personalProjects.map(item => ({
+        ...item,
+        bulletSummary: [...item.bulletSummary],
+    })),
+    certificates: data.certificates.map(item => ({ ...item })),
+    achievements: data.achievements.map(item => ({ ...item })),
+    configuration: { ...data.configuration },
+    enableInRender: { ...data.enableInRender },
+    template: {
+        whitepaper: {
+            ...data.template.whitepaper,
+            sectionOrder: [...data.template.whitepaper.sectionOrder],
+        },
+        classic: {
+            ...data.template.classic,
+            sectionOrder: [...data.template.classic.sectionOrder],
+        },
+        modern: {
+            ...data.template.modern,
+            sidebarSections: [...data.template.modern.sidebarSections],
+            mainSections: [...data.template.modern.mainSections],
+        },
+        "modern-alt": {
+            ...data.template["modern-alt"],
+            sectionOrder: [...data.template["modern-alt"].sectionOrder],
+        },
+    },
+})

--- a/src/features/editor/hooks/useConfiguration.ts
+++ b/src/features/editor/hooks/useConfiguration.ts
@@ -2,6 +2,7 @@ import type { ChangeEvent } from "react"
 import type { Configuration, TemplateConfig } from "@/entities/resume/types"
 import { useInterfaceStore } from "@/shared/store/useInterfaceStore"
 import { useResumeStore } from "@/entities/resume/store/useResumeStore"
+import { createResumeImportData } from "@/entities/resume/lib/importExport"
 import { MAX_IMPORT_SIZE_BYTES, isJsonFile, validateImportData } from "@/entities/resume/validation/import"
 import { useShallow } from "zustand/react/shallow"
 
@@ -62,42 +63,8 @@ export function useConfigurationHook() {
         amendTemplate(section, key, next as TemplateConfig[K][TemplateNumberKey<K>])
     }
 
-    const getData = () => {
-        const {
-            activePage,
-            personalDetails,
-            education,
-            references,
-            softSkills,
-            coreSkills,
-            workExperiences,
-            personalProjects,
-            certificates,
-            achievements,
-            configuration,
-            enableInRender,
-            template,
-        } = useResumeStore.getState()
-
-        return {
-            activePage,
-            personalDetails,
-            education,
-            references,
-            softSkills,
-            coreSkills,
-            workExperiences,
-            personalProjects,
-            certificates,
-            achievements,
-            configuration,
-            enableInRender,
-            template,
-        }
-    }
-
     const exportData = () => {
-        const data = getData()
+        const data = createResumeImportData(useResumeStore.getState())
         const timestamp = Math.floor(Date.now() / 1000)
         const fileName = `resume-data-${timestamp}.json`
 

--- a/test/e2e/app.spec.ts
+++ b/test/e2e/app.spec.ts
@@ -61,6 +61,70 @@ test.describe("resume editor", () => {
     await expect(page.getByRole("textbox", { name: "Position (Optional)" })).toHaveValue("Computer Scientist")
   })
 
+  test("downloaded app data can be imported back into a newly created resume", async ({ page }, testInfo) => {
+    await page.goto("/")
+    await page.getByRole("button", { name: "Get started" }).click()
+    await page.getByRole("button", { name: "I understand" }).click()
+
+    await page.getByRole("button", { name: "Data" }).click()
+
+    const downloadPromise = page.waitForEvent("download", (download) =>
+      download.suggestedFilename().endsWith(".json"),
+    )
+    await page.getByRole("button", { name: "Download your data" }).click()
+
+    const download = await downloadPromise
+    const exportedPath = testInfo.outputPath("resume-roundtrip.json")
+    await download.saveAs(exportedPath)
+
+    await page.locator('input[type="file"]').setInputFiles(exportedPath)
+
+    await expect(page.getByRole("alert").filter({ hasText: "Data import completed without issues" })).toBeVisible()
+    await expect(page.getByRole("alert").filter({ hasText: "The selected file does not match the required format" })).toHaveCount(0)
+  })
+
+  test("downloaded app data restores a non-default template after reset and re-import", async ({ page }, testInfo) => {
+    await page.goto("/")
+    await page.getByRole("button", { name: "Get started" }).click()
+    await page.getByRole("button", { name: "I understand" }).click()
+
+    await page.getByRole("button", { name: "Configuration" }).click()
+    await page.getByLabel("Select your theme").click()
+    await page.getByText("Modern", { exact: true }).click()
+    await page.getByRole("checkbox", { name: "Enable bullets" }).click()
+    await expect(page.getByRole("checkbox", { name: "Enable bullets" })).toBeChecked()
+
+    await page.getByRole("button", { name: "Data" }).click()
+
+    const downloadPromise = page.waitForEvent("download", (download) =>
+      download.suggestedFilename().endsWith(".json"),
+    )
+    await page.getByRole("button", { name: "Download your data" }).click()
+
+    const download = await downloadPromise
+    const exportedPath = testInfo.outputPath("resume-modern-roundtrip.json")
+    await download.saveAs(exportedPath)
+
+    await page.getByRole("button", { name: "Reset everything" }).click()
+    await page.getByRole("button", { name: "Confirm" }).click()
+
+    await page.getByRole("button", { name: "Configuration" }).click()
+    await expect(page.getByRole("group").filter({
+      has: page.getByText("Select your theme", { exact: true }),
+    }).first()).toContainText("Simple Whitepaper")
+
+    await page.getByRole("button", { name: "Data" }).click()
+    await page.locator('input[type="file"]').setInputFiles(exportedPath)
+
+    await expect(page.getByRole("alert").filter({ hasText: "Data import completed without issues" })).toBeVisible()
+
+    await page.getByRole("button", { name: "Configuration" }).click()
+    await expect(page.getByRole("group").filter({
+      has: page.getByText("Select your theme", { exact: true }),
+    }).first()).toContainText("Modern")
+    await expect(page.getByRole("checkbox", { name: "Enable bullets" })).toBeChecked()
+  })
+
   test("classic template is selectable, exposes parity controls, and persists after reload", async ({ page }) => {
     await page.goto("/")
     await page.getByRole("button", { name: "Get started" }).click()


### PR DESCRIPTION
## Logs

### Added
- Added Playwright round-trip coverage for Resume Makinator JSON exports, including a newly created resume case and a reset-and-restore template regression case.
- Added a shared resume import/export helper so app-generated JSON is assembled from one typed contract before download.

### Changed
- Changed the data export flow to serialize the shared `ResumeImportData` shape directly instead of rebuilding the JSON payload inline in the editor hook.