### PR TITLE
Version 3.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,4 @@ dist-ssr
 *.sln
 *.sw?
 
-# Personal configuration
-.agents
-tasks/
+.env

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@
   </p>
 </div>
 
-
-
 ## About the Project
 
 Resume Makinator started from a simple problem: a friend didn’t want to use Word to create a resume because of all the formatting, spacing, and layout work. To make the process simpler and more efficient, I built this project so that all they have to do is fill in structured fields and adjust a few options, instead of manually designing a document from scratch.
@@ -25,8 +23,6 @@ Resume Makinator started from a simple problem: a friend didn’t want to use Wo
 Right now, this project uses a single, opinionated template focused on clarity and readability. The goal is to expand this over time with more templates based on research into resume designs that are widely accepted and appropriate for different roles and industries.
 
 By making this tool public, I want to help anyone who struggles with creating a resume. No complicated editors, no layout headaches! just open it in the browser, fill in the blanks, toggle the sections you need, quickly fix the order of entries, and you’re ready to export.
-
-
 
 ### Features
 
@@ -36,8 +32,6 @@ By making this tool public, I want to help anyone who struggles with creating a 
 - Keep everything client-side, with data stored only in the browser.
 - Export and re-import your data as JSON to back it up or move between devices.
 - Preview your resume in a PDF-style viewer while you edit.
-
-
 
 ### Built With
 
@@ -51,8 +45,6 @@ By making this tool public, I want to help anyone who struggles with creating a 
 - **use-debounce** for smoothing out updates during rapid typing.
 - **nanoid** for generating stable IDs for dynamic list items.
 
-
-
 ## Contributing
 
 Contributions are welcome as long as they respect the license.
@@ -64,7 +56,9 @@ If you want to:
 - **Suggest an improvement** then open an issue or a discussion explaining what you’d like to see.
 - **Submit a fix or feature** then fork the repository, create a branch, and open a pull request.
 
+## Special Credits
 
+Special thanks to [Pollinations AI](https://pollinations.ai) for powering the chat assistant and making AI models accessible to builders.
 
 ## License
 

--- a/index.html
+++ b/index.html
@@ -4,18 +4,27 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="application-name" content="Resume Makinator" />
+    <meta name="apple-mobile-web-app-title" content="Resume Makinator" />
+    <meta name="author" content="MKGP" />
+    <meta
+      name="keywords"
+      content="resume builder, free resume builder, online resume builder, resume editor, PDF resume export, AI resume assistant, Resume Makinator"
+    />
     <meta
       name="description"
-      content="Build a polished resume in your browser with Resume Makinator. Fill structured sections, reorder content, preview live PDFs, and export fast."
+      content="Create a free resume in your browser with structured editing, live PDF preview, export tools, and chat assistant guidance for cleaner resume content."
     />
     <meta name="robots" content="index, follow" />
     <meta name="theme-color" content="#0f172a" />
     <link rel="canonical" href="https://rm.mkgpdev.xyz/" />
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="Resume Makinator | Free Resume Builder & PDF Export" />
+    <meta property="og:site_name" content="Resume Makinator" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:title" content="Resume Makinator | Free Online Resume Builder" />
     <meta
       property="og:description"
-      content="Build a polished resume in your browser with Resume Makinator. Fill structured sections, reorder content, preview live PDFs, and export fast."
+      content="Create a free resume in your browser with structured editing, live PDF preview, export tools, and chat assistant guidance for cleaner resume content."
     />
     <meta property="og:url" content="https://rm.mkgpdev.xyz/" />
     <meta property="og:image" content="https://rm.mkgpdev.xyz/logo.png" />
@@ -23,24 +32,49 @@
     <meta property="og:image:height" content="620" />
     <meta property="og:image:alt" content="Resume Makinator logo" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Resume Makinator | Free Resume Builder & PDF Export" />
+    <meta name="twitter:title" content="Resume Makinator | Free Online Resume Builder" />
     <meta
       name="twitter:description"
-      content="Build a polished resume in your browser with Resume Makinator. Fill structured sections, reorder content, preview live PDFs, and export fast."
+      content="Create a free resume in your browser with structured editing, live PDF preview, export tools, and chat assistant guidance for cleaner resume content."
     />
     <meta name="twitter:image" content="https://rm.mkgpdev.xyz/logo.png" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; form-action 'self'; object-src 'none'; frame-src 'self' blob:; img-src 'self' data: blob:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'wasm-unsafe-eval'; connect-src 'self' blob: data: ws://localhost:* ws://127.0.0.1:*;" />
-    <title>Resume Makinator | Free Resume Builder & PDF Export</title>
+    <meta name="twitter:image:alt" content="Resume Makinator logo" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; form-action 'self'; object-src 'none'; frame-src 'self' blob:; img-src 'self' data: blob:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'wasm-unsafe-eval'; connect-src 'self' blob: data: http://localhost:* http://127.0.0.1:* https://localhost:* https://127.0.0.1:* ws://localhost:* ws://127.0.0.1:* wss://localhost:* wss://127.0.0.1:* %VITE_API_BASE_URL%;" />
+    <title>Resume Makinator | Free Online Resume Builder</title>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "WebApplication",
         "name": "Resume Makinator",
+        "alternateName": "Resume Makinator resume builder",
         "url": "https://rm.mkgpdev.xyz/",
-        "description": "Build a polished resume in your browser with Resume Makinator. Fill structured sections, reorder content, preview live PDFs, and export fast.",
+        "description": "Create a free resume in your browser with structured editing, live PDF preview, export tools, and chat assistant guidance for cleaner resume content.",
         "applicationCategory": "BusinessApplication",
         "operatingSystem": "Web Browser",
-        "image": "https://rm.mkgpdev.xyz/logo.png"
+        "browserRequirements": "Requires a modern web browser with JavaScript enabled.",
+        "isAccessibleForFree": true,
+        "inLanguage": "en",
+        "image": "https://rm.mkgpdev.xyz/logo.png",
+        "featureList": [
+          "Free browser-based resume builder",
+          "Structured resume editing",
+          "Live PDF resume preview",
+          "Resume data import and export",
+          "Chat assistant guidance for resume content"
+        ],
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        },
+        "creator": {
+          "@type": "Person",
+          "name": "MKGP"
+        },
+        "potentialAction": {
+          "@type": "UseAction",
+          "target": "https://rm.mkgpdev.xyz/"
+        }
       }
     </script>
   </head>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="application-name" content="Resume Makinator" />
     <meta name="apple-mobile-web-app-title" content="Resume Makinator" />
-    <meta name="author" content="MKGP" />
+    <meta name="author" content="Mark Kenneth Pelayo" />
     <meta
       name="keywords"
       content="resume builder, free resume builder, online resume builder, resume editor, PDF resume export, AI resume assistant, Resume Makinator"
@@ -69,7 +69,7 @@
         },
         "creator": {
           "@type": "Person",
-          "name": "MKGP"
+          "name": "Mark Kenneth Pelayo"
         },
         "potentialAction": {
           "@type": "UseAction",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "resume-makinator",
   "private": true,
-  "version": "3.0.0",
+  "version": "3.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,6 +1,7 @@
 import { usePageHook } from "@/features/editor/hooks/usePage"
 import { Suspense, lazy, useCallback, useEffect, useRef, useState } from "react"
 import { ExclamationTriangleIcon } from "@heroicons/react/24/outline"
+import ChatAssistant from "@/features/chat-assistant/ChatAssistant"
 import Tab from "@/widgets/layout/Tab"
 import Default from "@/widgets/layout/Default"
 import Navigation from "@/widgets/layout/Navigation"
@@ -110,7 +111,7 @@ export default function App() {
         />
         <Navigation active={page} />
         <main className="flex flex-1 flex-col gap-5 lg:min-h-0 lg:flex-row lg:gap-6">
-          <section className="editor-panel-surface relative overflow-hidden rounded-[0.65rem] px-4 py-4 sm:px-5 lg:min-h-0 lg:w-[min(44vw,37rem)] lg:flex-none lg:px-6 lg:py-5">
+          <section className="editor-panel-surface editor-left-pane relative overflow-hidden rounded-[0.65rem] px-4 py-4 sm:px-5 lg:min-h-0 lg:w-[min(44vw,37rem)] lg:flex-none lg:px-6 lg:py-5">
             <div className="relative lg:h-full">
               <div
                 className={`editor-scroll-fade editor-scroll-fade-top hidden lg:block ${scrollFadeState.top ? "opacity-100" : "opacity-0"}`}
@@ -121,7 +122,7 @@ export default function App() {
               <div
                 ref={editorScrollRef}
                 onScroll={syncEditorScrollFade}
-                className={`primary-scroll overflow-visible lg:h-full lg:overflow-x-hidden lg:overflow-y-auto lg:pb-6 lg:pr-2 ${scrollMaskClass}`}
+                className={`primary-scroll -mx-1 px-1 overflow-visible lg:h-full lg:overflow-x-hidden lg:overflow-y-auto lg:pb-6 lg:pr-3 ${scrollMaskClass}`}
               >
                 <Tab active={page} />
               </div>
@@ -148,6 +149,7 @@ export default function App() {
 
         <Footer />
       </div>
+      <ChatAssistant />
     </div>
   )
 }

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -49,6 +49,8 @@
   --animate-panel-in: panel-in 0.24s cubic-bezier(0.22, 1, 0.36, 1) both;
   --animate-item-in: item-in 0.2s cubic-bezier(0.22, 1, 0.36, 1) both;
   --animate-item-out: item-out 0.18s ease-in forwards;
+  --animate-chat-message-in: chat-message-in 0.22s cubic-bezier(0.22, 1, 0.36, 1) both;
+  --animate-chat-card-in: chat-card-in 0.24s cubic-bezier(0.22, 1, 0.36, 1) both;
   --animate-landing-rise: landing-rise 0.5s cubic-bezier(0.22, 1, 0.36, 1) both;
   --animate-landing-float: landing-float 6s ease-in-out infinite;
   @keyframes fade-in {
@@ -104,6 +106,28 @@
     }
   }
 
+  @keyframes chat-message-in {
+    0% {
+      opacity: 0;
+      transform: translateY(8px) scale(0.985);
+    }
+    100% {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+  }
+
+  @keyframes chat-card-in {
+    0% {
+      opacity: 0;
+      transform: translateY(10px);
+    }
+    100% {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
   @keyframes landing-rise {
     0% {
       opacity: 0;
@@ -153,7 +177,17 @@
   }
 
   .editor-panel-surface {
-    @apply border border-base-300/80 bg-base-200/72 shadow-[0_18px_60px_rgba(2,6,23,0.32)] backdrop-blur-xl;
+    @apply border border-slate-400/18 bg-slate-900/44 shadow-[0_18px_60px_rgba(2,6,23,0.32)] backdrop-blur-2xl;
+  }
+
+  .editor-left-pane {
+    background-image:
+      linear-gradient(135deg, rgb(148 163 184 / 0.075), transparent 44%),
+      radial-gradient(circle at 20% 0%, rgb(125 211 252 / 0.08), transparent 32%),
+      linear-gradient(180deg, rgb(15 23 42 / 0.54), rgb(15 23 42 / 0.36));
+    box-shadow:
+      inset 0 1px 0 rgb(255 255 255 / 0.05),
+      0 22px 70px rgb(2 6 23 / 0.34);
   }
 
   .editor-glass-surface {
@@ -161,18 +195,48 @@
   }
 
   .editor-subtle-panel {
-    @apply border border-slate-500/28 bg-base-200/45 p-4 sm:p-5;
+    @apply border border-slate-500/34 bg-slate-800/32 p-4 sm:p-5;
   }
 
   .editor-control {
-    @apply border border-base-300 bg-base-200/80 text-base-content outline-none transition-[border-color,box-shadow,background-color] duration-150 placeholder:text-slate-500;
+    @apply border border-slate-500/38 bg-slate-900/42 text-base-content outline-none transition-[border-color,box-shadow,background-color] duration-150 placeholder:text-slate-500;
     box-shadow: none;
   }
 
+  .editor-control.input,
+  .editor-control.textarea {
+    border-color: rgb(100 116 139 / 0.38) !important;
+    background-color: rgb(15 23 42 / 0.42) !important;
+    color: rgb(248 250 252 / 0.94) !important;
+  }
+
+  .editor-control.input:hover,
+  .editor-control.textarea:hover {
+    border-color: rgb(148 163 184 / 0.46) !important;
+    background-color: rgb(30 41 59 / 0.44) !important;
+  }
+
+  .editor-file-control {
+    @apply border-slate-500/38 bg-slate-900/42 hover:border-slate-400/46 hover:bg-slate-800/44;
+  }
+
+  .editor-control:disabled,
+  .editor-control[aria-disabled="true"],
+  .editor-control.input:disabled,
+  .editor-control.textarea:disabled {
+    @apply border-slate-600/28 bg-slate-900/24 text-slate-500 placeholder:text-slate-600;
+    background-color: rgb(15 23 42 / 0.24) !important;
+    border-color: rgb(71 85 105 / 0.28) !important;
+    color: rgb(100 116 139 / 1) !important;
+  }
+
   .editor-control:focus,
-  .editor-control:focus-visible {
-    border-color: rgb(226 232 240 / 0.72);
-    box-shadow: inset 0 0 0 1px rgb(241 245 249 / 0.92);
+  .editor-control:focus-visible,
+  .editor-control:focus-within {
+    border-color: rgb(125 211 252 / 0.58);
+    box-shadow:
+      inset 0 0 0 1px rgb(186 230 253 / 0.34),
+      0 0 0 1px rgb(125 211 252 / 0.1);
     outline: none;
   }
 
@@ -181,7 +245,7 @@
   }
 
   .editor-section-rule {
-    @apply h-px flex-1 bg-slate-500/55;
+    @apply h-px flex-1 bg-slate-500;
   }
 
   .editor-scroll-fade {
@@ -214,6 +278,36 @@
   .editor-panel-enter {
     animation: var(--animate-panel-in);
     transform-origin: top;
+  }
+
+  .editor-chat-panel {
+    animation: var(--animate-panel-in);
+  }
+
+  .chat-assistant-message {
+    animation: var(--animate-chat-message-in);
+  }
+
+  .animate-chat-card-in {
+    animation: var(--animate-chat-card-in);
+  }
+
+  .chat-assistant-bubble {
+    max-width: min(82%, 21rem);
+  }
+
+  .chat.chat-assistant-message .chat-assistant-bubble::before,
+  .chat.chat-assistant-message .chat-assistant-bubble::after {
+    display: none !important;
+    content: none !important;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .editor-chat-panel,
+    .chat-assistant-message,
+    .animate-chat-card-in {
+      animation: none;
+    }
   }
 
   .editor-item-enter {

--- a/src/app/seo.ts
+++ b/src/app/seo.ts
@@ -1,6 +1,6 @@
 import type { ActivePage, PageId } from "@/app/navigation"
 
-export const SITE_TITLE = "Resume Makinator | Free Resume Builder & PDF Export"
+export const SITE_TITLE = "Resume Makinator | Free Online Resume Builder"
 
 const PAGE_TITLES: Record<PageId, string> = {
   about: "About You | Resume Makinator",

--- a/src/entities/resume/store/useResumeStore.ts
+++ b/src/entities/resume/store/useResumeStore.ts
@@ -85,6 +85,7 @@ const INITIAL_STATE: ResumeData & {
         fontStyle: "Lora",
         fontSize: 12,
         pageSize: "A4",
+        pollinationsApiKey: "",
     },
     enableInRender: {
         summary: true,
@@ -224,6 +225,9 @@ export const useResumeStore = create<ResumeStore>()(
                         configuration: {
                             ...currentState.configuration,
                             ...configuration,
+                            pollinationsApiKey: typeof configuration.pollinationsApiKey === "string"
+                                ? configuration.pollinationsApiKey
+                                : currentState.configuration.pollinationsApiKey,
                         },
                         enableInRender: {
                             ...currentState.enableInRender,

--- a/src/entities/resume/types.ts
+++ b/src/entities/resume/types.ts
@@ -113,6 +113,7 @@ export type Configuration = {
   fontStyle: FontStyle
   fontSize: number
   pageSize: PageSize
+  pollinationsApiKey: string
 }
 
 export type SharedTemplateConfig = {

--- a/src/entities/resume/validation/import.ts
+++ b/src/entities/resume/validation/import.ts
@@ -335,7 +335,11 @@ const isConfiguration = (value: unknown): value is Configuration => (
     isString(value.fontStyle) &&
     isNumberLike(value.fontSize) &&
     toNumber(value.fontSize) > 0 &&
-    isString(value.pageSize)
+    isString(value.pageSize) &&
+    (
+        !Object.prototype.hasOwnProperty.call(value, "pollinationsApiKey") ||
+        isString(value.pollinationsApiKey)
+    )
 )
 
 export const validateImportData = (data: unknown): ResumeImportData | null => {
@@ -371,6 +375,7 @@ export const validateImportData = (data: unknown): ResumeImportData | null => {
             ...data.configuration,
             template: normalizeTemplateId(data.configuration.template),
             fontSize: toNumber(data.configuration.fontSize),
+            pollinationsApiKey: toString(data.configuration.pollinationsApiKey),
         },
         enableInRender: renderConfig,
         template: templateConfig,

--- a/src/features/chat-assistant/ChatAssistant.tsx
+++ b/src/features/chat-assistant/ChatAssistant.tsx
@@ -1,0 +1,549 @@
+import {
+  ChatBubbleLeftRightIcon,
+  InformationCircleIcon,
+  PaperAirplaneIcon,
+  TrashIcon,
+  XMarkIcon,
+} from "@heroicons/react/24/outline"
+import clsx from "clsx"
+import { useEffect, useId, useRef, useState, type RefObject } from "react"
+import { useResumeStore } from "@/entities/resume/store/useResumeStore"
+import { toChatDisplayText } from "@/features/chat-assistant/lib/fieldLabels"
+import { formatDraftPreview } from "@/features/chat-assistant/lib/formatDraftPreview"
+import { resolveTargetItemLabel } from "@/features/chat-assistant/lib/resolveTargetItemLabel"
+import { useShallow } from "zustand/react/shallow"
+import Alert from "@/shared/ui/Alert"
+import Button from "@/shared/ui/Button"
+import Modal from "@/shared/ui/Modal"
+import { useChatAssistant } from "@/features/chat-assistant/hooks/useChatAssistant"
+import type { AiDraftChange } from "@/features/chat-assistant/types"
+
+function ClearConversationModal({
+  dialogRef,
+  onConfirm,
+}: {
+  dialogRef: RefObject<HTMLDialogElement | null>
+  onConfirm: () => void
+}) {
+  return (
+    <Modal
+      ref={dialogRef}
+      size="sm"
+      content={(
+        <div className="space-y-3">
+          <h3 className="font-manrope text-xl font-semibold text-slate-50">Clear conversation?</h3>
+          <p className="text-sm leading-6 text-slate-300">
+            This will remove the saved chat history from this browser. Your resume data will stay as it is.
+          </p>
+        </div>
+      )}
+      actions={(
+        <>
+          <Button
+            variant="surface"
+            text="Cancel"
+            onClick={() => dialogRef.current?.close()}
+          />
+          <Button
+            variant="danger"
+            text="Clear chat"
+            onClick={onConfirm}
+          />
+        </>
+      )}
+      allowOutsideClick={true}
+    />
+  )
+}
+
+function ChatAssistantInfoModal({
+  dialogRef,
+}: {
+  dialogRef: RefObject<HTMLDialogElement | null>
+}) {
+  return (
+    <Modal
+      ref={dialogRef}
+      size="md"
+      content={(
+        <div className="space-y-5">
+          <div>
+            <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.2em] text-sky-200/82">
+              <ChatBubbleLeftRightIcon className="size-4" />
+              <span>Chat Assistant</span>
+            </div>
+            <h3 className="mt-2 font-manrope text-xl font-semibold text-slate-50">
+              About your Assistant
+            </h3>
+          </div>
+
+          <div className="space-y-4 text-sm leading-6 text-slate-300">
+            <section className="rounded-[0.7rem] border border-slate-500/18 bg-slate-950/22 p-4">
+              <h4 className="font-manrope text-sm font-semibold text-slate-100">Early stage</h4>
+              <p className="mt-1">
+                The Chat Assistant is still in an early stage, so responses may be slow, it may ask for clarification from time to time, and it may not always be accurate. Clear intent matters here: broad or vague requests can lead to random or less useful output, while specific goals help the assistant stay on target. If you want to help improve this feature,
+                {" "}
+                <a
+                  href="https://github.com/mkgp-dev/resume-makinator/issues/new?template=bug_report.md"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="font-medium text-sky-200 underline-offset-4 transition-colors duration-150 hover:text-sky-100 hover:underline"
+                >
+                  send a report
+                </a>
+                .
+              </p>
+            </section>
+
+            <section className="rounded-[0.7rem] border border-slate-500/18 bg-slate-950/22 p-4">
+              <h4 className="font-manrope text-sm font-semibold text-slate-100">Powered by Pollinations AI</h4>
+              <p className="mt-1">
+                The assistant is proudly powered by Pollinations AI. You can add your own Pollinations key in the app configuration, which helps you continue using the assistant if the shared server allowance is depleted. As the developer, I am deeply grateful to Pollinations because it helped me learn how model configuration works and better understand what these models can and cannot do.
+              </p>
+            </section>
+
+            <section className="rounded-[0.7rem] border border-amber-300/18 bg-amber-400/8 p-4">
+              <h4 className="font-manrope text-sm font-semibold text-slate-100">Best results</h4>
+              <p className="mt-1">
+                For the best output, tackle one section at a time instead of asking it to handle everything at once. The assistant may struggle to respond well when a request covers too much, so focused section-by-section edits are the safest path for now. This limit will be improved further in the future.
+              </p>
+            </section>
+          </div>
+        </div>
+      )}
+      actions={(
+        <Button
+          variant="surface"
+          text="Close"
+          onClick={() => dialogRef.current?.close()}
+        />
+      )}
+      allowOutsideClick={true}
+    />
+  )
+}
+
+export default function ChatAssistant() {
+  const resumeData = useResumeStore(useShallow((state) => ({
+    personalProjects: state.personalProjects,
+    workExperiences: state.workExperiences,
+    education: state.education,
+    certificates: state.certificates,
+    achievements: state.achievements,
+    references: state.references,
+    coreSkills: state.coreSkills,
+  })))
+  const {
+    hasHydrated,
+    entries,
+    activeDraft,
+    activeClarification,
+    pending,
+    sendMessage,
+    acceptDraft,
+    rejectDraft,
+    clearConversation,
+  } = useChatAssistant()
+  const [isOpen, setIsOpen] = useState(false)
+  const [message, setMessage] = useState("")
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
+  const clearDialogRef = useRef<HTMLDialogElement | null>(null)
+  const infoDialogRef = useRef<HTMLDialogElement | null>(null)
+  const feedRef = useRef<HTMLDivElement | null>(null)
+  const textareaId = useId()
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return
+      setIsOpen(false)
+      triggerRef.current?.focus()
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [isOpen])
+
+  useEffect(() => {
+    const element = feedRef.current
+    if (!element) return
+    element.scrollTop = element.scrollHeight
+  }, [entries, activeDraft, pending, isOpen])
+
+  if (!hasHydrated) return null
+
+  const closePanel = () => {
+    setIsOpen(false)
+    window.requestAnimationFrame(() => {
+      triggerRef.current?.focus()
+    })
+  }
+
+  const openPanel = () => setIsOpen(true)
+
+  const handleSubmit = async () => {
+    const wasSent = await sendMessage(message)
+    if (wasSent) setMessage("")
+  }
+
+  const handleClearConversation = () => {
+    clearConversation()
+    clearDialogRef.current?.close()
+  }
+
+  const composerPlaceholder = activeClarification
+    ? "Answer the assistant's question to continue."
+    : "Please be gentle to your assistant."
+  const draftItemLabel = activeDraft
+    ? resolveTargetItemLabel(activeDraft.target, resumeData)
+    : null
+
+  const resolveDraftChangeItemLabel = activeDraft
+    ? (change: AiDraftChange) =>
+        resolveTargetItemLabel(
+          {
+            section: change.section,
+            itemId: change.itemId,
+            field: change.field,
+            scope: activeDraft.target.scope,
+          },
+          resumeData,
+        )
+    : undefined
+
+  const draftPreview = activeDraft
+    ? formatDraftPreview(
+        activeDraft.draft,
+        draftItemLabel,
+        resolveDraftChangeItemLabel,
+      )
+    : null
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        data-testid="chat-assistant-trigger"
+        aria-label="Open Chat Assistant"
+        onClick={openPanel}
+        className={clsx(
+          "fixed top-1/2 z-40 -translate-y-1/2 transition-opacity duration-200",
+          "right-3 flex items-center gap-2 rounded-[0.8rem] border border-slate-400/18 px-3 py-2.5 text-xs font-manrope font-semibold uppercase tracking-[0.18em] text-slate-100 shadow-[0_18px_40px_rgba(2,6,23,0.3)] hover:border-sky-200/36 lg:right-[-2.85rem] lg:-rotate-90 lg:gap-2.5 lg:rounded-t-[0.9rem] lg:border lg:border-slate-400/20 lg:bg-slate-900/88 lg:px-4 lg:py-3 lg:text-sm lg:tracking-[0.08em] lg:backdrop-blur-xl",
+          "editor-glass-surface lg:border-slate-400/20 lg:bg-slate-900/88",
+          isOpen && "pointer-events-none opacity-0",
+        )}
+      >
+        <ChatBubbleLeftRightIcon className="size-4 text-sky-200 lg:rotate-90" />
+        <span className="lg:hidden">Chat</span>
+        <span className="hidden lg:block lg:rotate-180">Chat Assistant</span>
+      </button>
+
+      {isOpen ? (
+        <div className="fixed inset-0 z-40">
+          <button
+            type="button"
+            aria-label="Close Chat Assistant"
+            className="absolute inset-0 bg-slate-950/38 backdrop-blur-[2px]"
+            onClick={closePanel}
+          />
+
+          <aside
+            data-testid="chat-assistant-panel"
+            className="editor-chat-panel editor-glass-surface absolute inset-0 flex flex-col overflow-hidden border-0 sm:inset-y-4 sm:right-4 sm:left-auto sm:w-[min(28rem,calc(100vw-2rem))] sm:rounded-[1rem] sm:border"
+          >
+            <div className="border-b border-slate-400/14 px-4 py-4 sm:px-5">
+              <div className="flex items-center justify-between gap-4">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.22em] text-sky-200/82">
+                    <ChatBubbleLeftRightIcon className="size-3.5 shrink-0" />
+                    <span>Chat Assistant</span>
+                  </div>
+                  <p className="mt-2 text-[11px] uppercase tracking-[0.18em] text-slate-500">
+                    <a
+                      href="https://pollinations.ai"
+                      target="_blank"
+                      rel="noreferrer"
+                      className="transition-colors duration-150 hover:text-sky-200"
+                    >
+                      Powered with Pollinations.ai
+                    </a>
+                  </p>
+                </div>
+
+                <div className="flex shrink-0 items-center gap-2">
+                  <button
+                    type="button"
+                    aria-label="About your Assistant"
+                    className="flex size-10 items-center justify-center rounded-[0.55rem] border border-slate-400/14 bg-base-200/40 text-slate-300 transition-colors duration-150 hover:border-sky-200/30 hover:bg-sky-400/10 hover:text-sky-100"
+                    onClick={() => infoDialogRef.current?.showModal()}
+                  >
+                    <InformationCircleIcon className="size-5" />
+                  </button>
+
+                  <button
+                    type="button"
+                    aria-label="Close Chat Assistant"
+                    className="flex size-10 items-center justify-center rounded-[0.55rem] border border-slate-400/14 bg-base-200/40 text-slate-300 transition-colors duration-150 hover:border-slate-300/24 hover:bg-base-200/65 hover:text-slate-50"
+                    onClick={closePanel}
+                  >
+                    <XMarkIcon className="size-5" />
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            <div
+              ref={feedRef}
+              className="primary-scroll flex-1 space-y-3 overflow-y-auto px-4 py-4 sm:px-5"
+            >
+              {!entries.length ? (
+                <div className="flex min-h-full items-center justify-center">
+                  <div className="max-w-sm rounded-[0.9rem] border border-slate-400/12 bg-slate-950/28 px-5 py-6 text-center">
+                    <div className="mx-auto flex size-12 items-center justify-center rounded-full border border-sky-300/20 bg-sky-400/10 text-sky-200">
+                      <ChatBubbleLeftRightIcon className="size-6" />
+                    </div>
+                    <p className="mt-4 font-manrope text-base font-semibold text-slate-50">
+                      Ask about a specific part of your resume
+                    </p>
+                    <p className="mt-2 text-sm leading-6 text-slate-400">
+                      Ask to add, edit, or remove content in one specific section at a time.
+                    </p>
+                  </div>
+                </div>
+              ) : null}
+
+              {entries.map((entry) => {
+                if (entry.kind === "notice") {
+                  return (
+                    <div
+                      key={entry.id}
+                      data-testid={entry.variant === "error" ? "chat-inline-error" : undefined}
+                    >
+                      <Alert
+                        text={toChatDisplayText(entry.text)}
+                        variant={entry.variant}
+                        isSoft={true}
+                      />
+                    </div>
+                  )
+                }
+
+                return (
+                  <div
+                    key={entry.id}
+                    className={clsx(
+                      "chat chat-assistant-message",
+                      entry.role === "user"
+                        ? "chat-end chat-assistant-message--user"
+                        : "chat-start chat-assistant-message--assistant",
+                    )}
+                  >
+                    <div
+                      data-testid="chat-message-bubble"
+                      className={clsx(
+                        "chat-bubble chat-assistant-bubble whitespace-pre-wrap rounded-[0.85rem] border text-sm leading-6 shadow-none",
+                        entry.role === "user"
+                          ? "chat-assistant-bubble--user border-primary/40 bg-primary/92 text-primary-content"
+                          : "chat-assistant-bubble--assistant border-slate-400/16 bg-base-200/68 text-slate-100",
+                      )}
+                    >
+                      {entry.role === "assistant" ? toChatDisplayText(entry.text) : entry.text}
+                    </div>
+                  </div>
+                )
+              })}
+
+              {pending && !activeDraft ? (
+                <div className="rounded-[0.8rem] border border-slate-400/12 bg-slate-950/30 px-4 py-3 text-sm text-slate-300">
+                  <div className="flex items-center gap-3">
+                    <span className="loading loading-dots loading-sm text-sky-200" />
+                    <span>Hang tight while we prepare a response</span>
+                  </div>
+                </div>
+              ) : null}
+
+              {activeClarification ? (
+                <div className="animate-chat-card-in rounded-[0.9rem] border border-amber-300/18 bg-amber-400/8 px-4 py-4">
+                  <div className="text-[11px] uppercase tracking-[0.2em] text-amber-200/82">
+                    Need details before I can continue
+                  </div>
+                  <p className="mt-2 font-manrope text-base font-semibold text-slate-50">
+                    {toChatDisplayText(activeClarification.question)}
+                  </p>
+                </div>
+              ) : null}
+
+              {activeDraft ? (
+                <div
+                  data-testid="chat-draft-review"
+                  className="animate-chat-card-in rounded-[0.9rem] border border-sky-300/16 bg-sky-400/8 px-4 py-4"
+                >
+                  {pending ? (
+                    <div
+                      data-testid="chat-draft-loading"
+                      className="flex min-h-44 flex-col items-center justify-center text-center"
+                    >
+                      <span className="loading loading-dots loading-md text-sky-200" />
+                      <p className="mt-3 font-manrope text-sm font-semibold text-slate-100">
+                        Updating draft
+                      </p>
+                      <p className="mt-1 max-w-xs text-sm leading-6 text-slate-400">
+                        I’m updating the content, please wait.
+                      </p>
+                    </div>
+                  ) : (
+                    <>
+                      <div className="text-[11px] uppercase tracking-[0.2em] text-sky-200/78">
+                        Review draft
+                      </div>
+                      <p className="mt-2 font-manrope text-base font-semibold text-slate-50">
+                        {toChatDisplayText(activeDraft.draft.summary)}
+                      </p>
+                      {draftPreview?.entries.length ? (
+                        <div className="mt-3 space-y-4 text-sm leading-6 text-slate-300">
+                          {draftPreview.entries.map((entry, index) => (
+                            <div
+                              key={`draft-preview-${index}`}
+                              className="space-y-2 border-t border-slate-400/10 pt-3 first:border-t-0 first:pt-0"
+                            >
+                              {entry.metadata ? (
+                                <nav
+                                  aria-label="Draft target"
+                                  data-testid="chat-draft-breadcrumbs"
+                                  className="breadcrumbs max-w-full overflow-hidden py-0 text-[11px] uppercase tracking-[0.16em] text-slate-400"
+                                >
+                                  <ul className="min-h-0">
+                                    {entry.metadata.map((part, partIndex) => (
+                                      <li key={`${part}-${partIndex}`}>
+                                        <span>{part}</span>
+                                      </li>
+                                    ))}
+                                  </ul>
+                                </nav>
+                              ) : null}
+
+                              {entry.kind === "text" ? (
+                                <p className="whitespace-pre-wrap text-sm leading-6 text-slate-300">
+                                  {entry.text}
+                                </p>
+                              ) : null}
+
+                              {entry.kind === "bullets" ? (
+                                <ul className="space-y-2 text-sm leading-6 text-slate-300">
+                                  {entry.items.map((item) => (
+                                    <li key={item} className="flex items-start gap-2.5">
+                                      <span className="mt-[0.55rem] size-1.5 shrink-0 rounded-full bg-sky-200/80" />
+                                      <span>{item}</span>
+                                    </li>
+                                  ))}
+                                </ul>
+                              ) : null}
+
+                              {entry.kind === "coreSkills" ? (
+                                <dl className="divide-y divide-slate-400/10 text-sm">
+                                  <div className="grid gap-1 py-2.5 text-slate-300 first:pt-0 last:pb-0 sm:grid-cols-[minmax(8rem,0.45fr)_1fr] sm:gap-3">
+                                    <dt className="font-medium text-slate-100">
+                                      {entry.isNewGroup ? "New group" : "Group"}
+                                    </dt>
+                                    <dd className="text-slate-300">{entry.groupName}</dd>
+                                  </div>
+                                  <div className="grid gap-1 py-2.5 text-slate-300 first:pt-0 last:pb-0 sm:grid-cols-[minmax(8rem,0.45fr)_1fr] sm:gap-3">
+                                    <dt className="font-medium text-slate-100">Skills</dt>
+                                    <dd className="text-slate-300">{entry.skills.join(", ")}</dd>
+                                  </div>
+                                </dl>
+                              ) : null}
+
+                              {entry.kind === "fields" ? (
+                                <dl className="divide-y divide-slate-400/10 text-sm">
+                                  {entry.rows.map((row) => (
+                                    <div
+                                      key={`${row.label}-${row.value}`}
+                                      className="grid gap-1 py-2.5 text-slate-300 first:pt-0 last:pb-0 sm:grid-cols-[minmax(8rem,0.45fr)_1fr] sm:gap-3"
+                                    >
+                                      <dt className="font-medium text-slate-100">{row.label}</dt>
+                                      <dd className="text-slate-300">{row.value}</dd>
+                                    </div>
+                                  ))}
+                                </dl>
+                              ) : null}
+                            </div>
+                          ))}
+                        </div>
+                      ) : null}
+
+                      <div className="mt-4 flex flex-wrap gap-2">
+                        <Button
+                          text="Accept"
+                          onClick={() => void acceptDraft()}
+                          isDisabled={pending}
+                        />
+                        <Button
+                          variant="surface"
+                          text="Reject"
+                          onClick={rejectDraft}
+                          isDisabled={pending}
+                        />
+                      </div>
+                    </>
+                  )}
+                </div>
+              ) : null}
+            </div>
+
+            <div className="border-t border-slate-400/14 bg-slate-950/14 px-4 py-4 sm:px-5">
+              <div className="space-y-3">
+                <textarea
+                  id={textareaId}
+                  aria-label="Message"
+                  rows={4}
+                  value={message}
+                  disabled={pending}
+                  onChange={(event) => setMessage(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key !== "Enter" || event.shiftKey) return
+                    event.preventDefault()
+                    void handleSubmit()
+                  }}
+                  placeholder={composerPlaceholder}
+                  className="editor-control textarea min-h-28 w-full resize-none rounded-[0.75rem] border border-slate-400/14 bg-base-200/54 px-4 py-3 text-sm leading-6"
+                />
+
+                <div className="flex flex-wrap items-center gap-2">
+                  <button
+                    type="button"
+                    aria-label="Send message"
+                    onClick={() => void handleSubmit()}
+                    disabled={pending || !message.trim()}
+                    className="btn btn-sm border border-sky-300/24 bg-sky-400/14 font-manrope text-sm font-medium normal-case text-sky-100 shadow-none transition-colors duration-150 hover:border-sky-200/38 hover:bg-sky-400/20 disabled:cursor-not-allowed disabled:border-slate-500/14 disabled:bg-slate-900/30 disabled:text-slate-500"
+                  >
+                    <PaperAirplaneIcon className="size-4" />
+                    <span>Send</span>
+                  </button>
+
+                  <button
+                    type="button"
+                    aria-label="Clear conversation"
+                    onClick={() => clearDialogRef.current?.showModal()}
+                    className="btn btn-sm border border-slate-500/24 bg-base-200/32 font-manrope text-sm font-medium normal-case text-slate-300 shadow-none transition-colors duration-150 hover:border-slate-300/30 hover:bg-base-200/52 hover:text-slate-100"
+                  >
+                    <TrashIcon className="size-4" />
+                    <span>Clear conversation</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </aside>
+        </div>
+      ) : null}
+
+      <ClearConversationModal
+        dialogRef={clearDialogRef}
+        onConfirm={handleClearConversation}
+      />
+      <ChatAssistantInfoModal dialogRef={infoDialogRef} />
+    </>
+  )
+}

--- a/src/features/chat-assistant/api/sendChatAssistantRequest.ts
+++ b/src/features/chat-assistant/api/sendChatAssistantRequest.ts
@@ -1,0 +1,126 @@
+import type { AiChatMode, AiChatRequest, AiChatResponse } from "@/features/chat-assistant/types"
+import { useResumeStore } from "@/entities/resume/store/useResumeStore"
+
+const POLLINATIONS_KEY_PATTERN = /^(sk|pk)_[A-Za-z0-9]{32}$/
+
+type ErrorShape = {
+  error?: {
+    code?: string
+    message?: string
+    requestId?: string
+  }
+}
+
+export class ChatAssistantRequestError extends Error {
+  status: number
+  code?: string
+  requestId?: string
+
+  constructor({
+    message,
+    status,
+    code,
+    requestId,
+  }: {
+    message: string
+    status: number
+    code?: string
+    requestId?: string
+  }) {
+    super(message)
+    this.name = "ChatAssistantRequestError"
+    this.status = status
+    this.code = code
+    this.requestId = requestId
+  }
+}
+
+const createEndpoint = () => {
+  const baseUrl = (import.meta.env.VITE_API_BASE_URL ?? "").trim().replace(/\/+$/, "")
+  return `${baseUrl}/v1/ai/chat`
+}
+
+const isAiChatMode = (value: unknown): value is AiChatMode =>
+  value === "exact_edit" ||
+  value === "grounded_suggestion" ||
+  value === "role_targeted_suggestion"
+
+const isAiChatResponse = (value: unknown): value is AiChatResponse => {
+  if (typeof value !== "object" || value === null) return false
+  const candidate = value as Partial<AiChatResponse>
+  const hasClarificationQuestion =
+    typeof candidate.clarificationQuestion === "string" ||
+    candidate.clarificationQuestion === null
+
+  return (
+    typeof candidate.reply === "string" &&
+    typeof candidate.provider === "string" &&
+    isAiChatMode(candidate.mode) &&
+    typeof candidate.status === "string" &&
+    hasClarificationQuestion &&
+    typeof candidate.needsClarification === "boolean" &&
+    typeof candidate.needsConfirmation === "boolean" &&
+    typeof candidate.readyToApply === "boolean" &&
+    Array.isArray(candidate.warnings)
+  )
+}
+
+const parseErrorResponse = async (response: Response) => {
+  let payload: ErrorShape | null = null
+
+  try {
+    payload = (await response.json()) as ErrorShape
+  } catch {
+    payload = null
+  }
+
+  const message = payload?.error?.message?.trim() || response.statusText || "Request failed"
+
+  throw new ChatAssistantRequestError({
+    status: response.status,
+    code: payload?.error?.code,
+    requestId: payload?.error?.requestId,
+    message,
+  })
+}
+
+export const sendChatAssistantRequest = async (
+  payload: AiChatRequest,
+): Promise<AiChatResponse> => {
+  let response: Response
+  const pollinationsApiKey = useResumeStore.getState().configuration.pollinationsApiKey.trim()
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  }
+
+  if (POLLINATIONS_KEY_PATTERN.test(pollinationsApiKey)) {
+    headers.Authorization = `Bearer ${pollinationsApiKey}`
+  }
+
+  try {
+    response = await fetch(createEndpoint(), {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload),
+    })
+  } catch {
+    throw new ChatAssistantRequestError({
+      status: 0,
+      message: "The chat service could not be reached. Check your API base URL and try again.",
+    })
+  }
+
+  if (!response.ok) {
+    await parseErrorResponse(response)
+  }
+
+  const data = (await response.json()) as unknown
+  if (!isAiChatResponse(data)) {
+    throw new ChatAssistantRequestError({
+      status: 502,
+      message: "The chat service returned an unexpected response shape.",
+    })
+  }
+
+  return data
+}

--- a/src/features/chat-assistant/hooks/useChatAssistant.ts
+++ b/src/features/chat-assistant/hooks/useChatAssistant.ts
@@ -1,0 +1,246 @@
+import { useShallow } from "zustand/react/shallow"
+import { createResumeImportData } from "@/entities/resume/lib/importExport"
+import { useResumeStore } from "@/entities/resume/store/useResumeStore"
+import { sendChatAssistantRequest, ChatAssistantRequestError } from "@/features/chat-assistant/api/sendChatAssistantRequest"
+import { applyAiDraftChanges } from "@/features/chat-assistant/lib/applyDraft"
+import { buildConversationWindow } from "@/features/chat-assistant/lib/buildConversationWindow"
+import { inferPendingAction } from "@/features/chat-assistant/lib/inferPendingAction"
+import { parseChatUserDecision } from "@/features/chat-assistant/lib/parseChatUserDecision"
+import { createChatResumeData } from "@/features/chat-assistant/lib/resumePayload"
+import { useChatAssistantStore } from "@/features/chat-assistant/store/useChatAssistantStore"
+import type {
+  AiActiveDraft,
+  AiChatResponse,
+  AiDraft,
+  ChatActionableDraft,
+  ChatResumeData,
+  ChatUserDecision,
+} from "@/features/chat-assistant/types"
+
+const REJECTED_DRAFT_MESSAGE =
+  "This draft is still not applied. Let me know if you want to add something or if you've changed your mind."
+const NOT_READY_TO_APPLY_MESSAGE =
+  "The latest reply is not ready to apply yet. Please continue the conversation until the assistant confirms the final draft."
+const APPLIED_DRAFT_MESSAGE =
+  "Done. I applied that update to your resume. What would you like to improve next?"
+
+const formatWarning = (warning: string) => warning.trim()
+
+const formatError = (error: unknown) => {
+  if (error instanceof ChatAssistantRequestError) {
+    return error.message
+  }
+
+  return "Something went wrong while talking to the chat service."
+}
+
+const buildActiveDraftPayload = (
+  activeDraft: ChatActionableDraft | null,
+): AiActiveDraft | undefined => {
+  if (!activeDraft?.mode) return undefined
+
+  return {
+    mode: activeDraft.mode,
+    target: activeDraft.target,
+    draft: activeDraft.draft,
+  }
+}
+
+export function useChatAssistant() {
+  const {
+    hasHydrated,
+    entries,
+    activeDraft,
+    activeClarification,
+    pendingAction,
+    lastUserMessage,
+    pending,
+    appendMessage,
+    appendNotice,
+    setActiveDraft,
+    setActiveClarification,
+    setPendingAction,
+    setLastUserMessage,
+    setPending,
+    clearConversation,
+  } = useChatAssistantStore(useShallow((state) => ({
+    hasHydrated: state.hasHydrated,
+    entries: state.entries,
+    activeDraft: state.activeDraft,
+    activeClarification: state.activeClarification,
+    pendingAction: state.pendingAction,
+    lastUserMessage: state.lastUserMessage,
+    pending: state.pending,
+    appendMessage: state.appendMessage,
+    appendNotice: state.appendNotice,
+    setActiveDraft: state.setActiveDraft,
+    setActiveClarification: state.setActiveClarification,
+    setPendingAction: state.setPendingAction,
+    setLastUserMessage: state.setLastUserMessage,
+    setPending: state.setPending,
+    clearConversation: state.clearConversation,
+  })))
+  const applyResumeData = useResumeStore((state) => state.setData)
+
+  const applyDraftLocally = (draft: AiDraft) => {
+    const currentResumeData = createResumeImportData(useResumeStore.getState())
+    const applyResult = applyAiDraftChanges(currentResumeData, draft.proposedChanges)
+
+    if (!applyResult.ok) {
+      appendNotice("error", applyResult.error)
+      return false
+    }
+
+    applyResumeData(applyResult.data)
+    setActiveDraft(null)
+    setActiveClarification(null)
+    setPendingAction(null)
+    appendMessage("assistant", APPLIED_DRAFT_MESSAGE)
+    return true
+  }
+
+  const consumeResponse = (
+    response: AiChatResponse,
+    requestMessage: string,
+    requestResumeData: ChatResumeData,
+    requestDecision: ChatUserDecision | null,
+  ) => {
+    appendMessage("assistant", response.reply)
+
+    for (const warning of response.warnings.map(formatWarning).filter(Boolean)) {
+      appendNotice("warning", warning)
+    }
+
+    setActiveClarification(null)
+    setActiveDraft(null)
+
+    const nextPendingAction = inferPendingAction(response, requestResumeData)
+    setPendingAction(nextPendingAction)
+
+    if (response.status === "clarification_needed") {
+      if (response.clarificationQuestion) {
+        setActiveClarification({
+          question: response.clarificationQuestion,
+        })
+      } else {
+        appendNotice("warning", "The assistant needs clarification, but no explicit question was returned.")
+      }
+      return
+    }
+
+    if (response.status === "draft_ready" || response.status === "awaiting_confirmation") {
+      if (requestDecision) {
+        setPendingAction(null)
+      }
+      if (response.draft) {
+        setActiveDraft({
+          requestMessage,
+          mode: response.mode,
+          draft: response.draft,
+          target: response.target,
+        })
+      }
+      if (!response.readyToApply) return
+    }
+
+    if (response.status === "blocked") {
+      if (requestDecision) {
+        setPendingAction(null)
+      }
+      return
+    }
+
+    if (!response.readyToApply) {
+      if (response.draft) {
+        appendNotice("warning", NOT_READY_TO_APPLY_MESSAGE)
+      }
+      return
+    }
+
+    if (!response.draft) {
+      appendNotice("error", "The AI confirmed a change, but it did not provide a draft to apply.")
+      return
+    }
+
+    applyDraftLocally(response.draft)
+  }
+
+  const sendMessage = async (message: string) => {
+    const trimmedMessage = message.trim()
+    if (!trimmedMessage || pending) return false
+
+    const resumeState = useResumeStore.getState()
+    const conversation = buildConversationWindow(entries)
+    const requestActiveDraft = buildActiveDraftPayload(activeDraft)
+    const requestResumeData = createChatResumeData(resumeState)
+    const userDecision = pendingAction ? parseChatUserDecision(trimmedMessage) : null
+    const requestPendingAction = userDecision ? pendingAction : null
+    const pendingDecisionPayload = requestPendingAction && userDecision
+      ? {
+          pendingAction: requestPendingAction,
+          userDecision,
+        }
+      : {}
+
+    if (pendingAction && !userDecision) {
+      setPendingAction(null)
+    }
+
+    appendMessage("user", trimmedMessage)
+    setLastUserMessage(trimmedMessage)
+    setPending(true)
+    setActiveClarification(null)
+
+    try {
+      const response = await sendChatAssistantRequest({
+        message: trimmedMessage,
+        resumeData: requestResumeData,
+        conversation,
+        activeDraft: requestActiveDraft,
+        ...pendingDecisionPayload,
+      })
+
+      consumeResponse(response, trimmedMessage, requestResumeData, userDecision)
+      return true
+    } catch (error) {
+      appendNotice("error", formatError(error))
+      return false
+    } finally {
+      setPending(false)
+    }
+  }
+
+  const acceptDraft = async () => {
+    if (!activeDraft || pending) return
+
+    setPending(true)
+
+    try {
+      applyDraftLocally(activeDraft.draft)
+    } finally {
+      setPending(false)
+    }
+  }
+
+  const rejectDraft = () => {
+    if (!activeDraft) return
+    setActiveDraft(null)
+    setActiveClarification(null)
+    setPendingAction(null)
+    appendMessage("assistant", REJECTED_DRAFT_MESSAGE)
+  }
+
+  return {
+    hasHydrated,
+    entries,
+    activeDraft,
+    activeClarification,
+    pendingAction,
+    lastUserMessage,
+    pending,
+    sendMessage,
+    acceptDraft,
+    rejectDraft,
+    clearConversation,
+  }
+}

--- a/src/features/chat-assistant/lib/applyDraft.ts
+++ b/src/features/chat-assistant/lib/applyDraft.ts
@@ -1,0 +1,495 @@
+import { nanoid } from "nanoid"
+import { validateImportData } from "@/entities/resume/validation/import"
+import { dedupeDraftListItems, normalizeDraftListItem, parseDraftStringList } from "@/features/chat-assistant/lib/stringListDraft"
+import { parseDraftJsonObject } from "@/features/chat-assistant/lib/structuredDraftJson"
+import type { ResumeImportData } from "@/entities/resume/types"
+import type { AiDraftChange } from "@/features/chat-assistant/types"
+
+type ApplyDraftResult =
+  | { ok: true; data: ResumeImportData }
+  | { ok: false; error: string }
+
+type UnknownRecord = Record<string, unknown>
+
+const isPlainObject = (value: unknown): value is UnknownRecord =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((item) => typeof item === "string")
+
+const parseDraftBoolean = (value: string) => {
+  const normalized = value.trim().toLowerCase()
+
+  if (normalized === "true") return true
+  if (normalized === "false") return false
+
+  return null
+}
+
+const parseDraftString = (value: unknown) => {
+  if (typeof value === "string") return value.trim()
+  if (typeof value === "number" && Number.isFinite(value)) return String(value)
+  return null
+}
+
+const isEmptyListPayload = (value: unknown): boolean => {
+  if (Array.isArray(value)) {
+    return value.length === 0
+  }
+
+  if (typeof value !== "string") {
+    return false
+  }
+
+  const normalized = value.trim()
+  if (normalized === "[]") {
+    return true
+  }
+
+  try {
+    const parsed = JSON.parse(normalized) as unknown
+    return typeof parsed === "string"
+      ? isEmptyListPayload(parsed)
+      : Array.isArray(parsed) && parsed.length === 0
+  } catch {
+    return false
+  }
+}
+
+const isRemoveItemDraft = (proposedText: unknown) => {
+  if (proposedText === null) return true
+
+  if (typeof proposedText !== "string") {
+    return isEmptyListPayload(proposedText)
+  }
+
+  const normalized = proposedText.trim()
+  return normalized === "" || isEmptyListPayload(proposedText)
+}
+
+const isClearSectionDraft = (change: AiDraftChange) =>
+  !change.itemId && !change.field && isEmptyListPayload(change.proposedText)
+
+const parseCoreSkillsCreateDraft = (proposedText: string) => {
+  const parsed = parseDraftJsonObject(proposedText)
+  if (!parsed) return null
+
+  const devLanguage =
+    typeof parsed.devLanguage === "string"
+      ? normalizeDraftListItem(parsed.devLanguage)
+      : ""
+  const devFramework = isStringArray(parsed.devFramework)
+    ? dedupeDraftListItems(
+        parsed.devFramework
+          .map(normalizeDraftListItem)
+          .filter(Boolean),
+      )
+    : []
+
+  if (!devLanguage || devFramework.length === 0) {
+    return null
+  }
+
+  return {
+    devLanguage,
+    devFramework,
+  }
+}
+
+const parsePersonalProjectCreateDraft = (proposedText: string) => {
+  const parsed = parseDraftJsonObject(proposedText)
+  if (!parsed) return null
+
+  if (
+    typeof parsed.projectName !== "string" ||
+    typeof parsed.projectSubtitle !== "string" ||
+    typeof parsed.preview !== "string" ||
+    typeof parsed.briefSummary !== "string" ||
+    typeof parsed.bulletType !== "boolean" ||
+    !isStringArray(parsed.bulletSummary)
+  ) {
+    return null
+  }
+
+  return {
+    projectName: parsed.projectName.trim(),
+    projectSubtitle: parsed.projectSubtitle.trim(),
+    preview: parsed.preview.trim(),
+    briefSummary: parsed.briefSummary.trim(),
+    bulletType: parsed.bulletType,
+    bulletSummary: dedupeDraftListItems(
+      parsed.bulletSummary
+        .map(normalizeDraftListItem)
+        .filter(Boolean),
+    ),
+  }
+}
+
+const parseWorkExperienceCreateDraft = (proposedText: string) => {
+  const parsed = parseDraftJsonObject(proposedText)
+  if (!parsed) return null
+
+  if (
+    typeof parsed.companyName !== "string" ||
+    typeof parsed.jobTitle !== "string" ||
+    typeof parsed.briefSummary !== "string" ||
+    typeof parsed.startYear !== "string" ||
+    typeof parsed.endYear !== "string" ||
+    typeof parsed.currentlyHired !== "boolean" ||
+    typeof parsed.bulletType !== "boolean" ||
+    !isStringArray(parsed.bulletSummary)
+  ) {
+    return null
+  }
+
+  return {
+    companyName: parsed.companyName.trim(),
+    jobTitle: parsed.jobTitle.trim(),
+    briefSummary: parsed.briefSummary.trim(),
+    startYear: parsed.startYear.trim(),
+    endYear: parsed.endYear.trim(),
+    currentlyHired: parsed.currentlyHired,
+    bulletType: parsed.bulletType,
+    bulletSummary: dedupeDraftListItems(
+      parsed.bulletSummary
+        .map(normalizeDraftListItem)
+        .filter(Boolean),
+    ),
+  }
+}
+
+const parseCertificateCreateDraft = (proposedText: string) => {
+  const parsed = parseDraftJsonObject(proposedText)
+  if (!parsed) return null
+
+  const certificateName = parseDraftString(parsed.certificateName)
+  const certificateIssuer = parseDraftString(parsed.certificateIssuer)
+  const yearIssued = parseDraftString(parsed.yearIssued)
+  const certificateDescription = parseDraftString(parsed.certificateDescription)
+
+  if (
+    certificateName === null ||
+    certificateIssuer === null ||
+    yearIssued === null ||
+    certificateDescription === null
+  ) {
+    return null
+  }
+
+  return {
+    certificateName,
+    certificateIssuer,
+    yearIssued,
+    certificateDescription,
+  }
+}
+
+const parseAchievementCreateDraft = (proposedText: string) => {
+  const parsed = parseDraftJsonObject(proposedText)
+  if (!parsed) return null
+
+  const achievementName = parseDraftString(parsed.achievementName)
+  const achievementIssuer = parseDraftString(parsed.achievementIssuer)
+  const yearIssued = parseDraftString(parsed.yearIssued)
+  const achievementDescription = parseDraftString(parsed.achievementDescription)
+
+  if (
+    achievementName === null ||
+    achievementIssuer === null ||
+    yearIssued === null ||
+    achievementDescription === null
+  ) {
+    return null
+  }
+
+  return {
+    achievementName,
+    achievementIssuer,
+    yearIssued,
+    achievementDescription,
+  }
+}
+
+const assignFieldValue = (
+  record: UnknownRecord,
+  field: string,
+  proposedText: string,
+): ApplyDraftResult | null => {
+  if (!Object.prototype.hasOwnProperty.call(record, field)) {
+    return { ok: false, error: `The AI draft targeted an unsupported field: ${field}.` }
+  }
+
+  const currentValue = record[field]
+
+  if (typeof currentValue === "string") {
+    record[field] = proposedText
+    return null
+  }
+
+  if (isStringArray(currentValue)) {
+    if (isEmptyListPayload(proposedText)) {
+      record[field] = []
+      return null
+    }
+
+    const nextValues = parseDraftStringList(proposedText)
+    if (!nextValues.ok) {
+      return { ok: false, error: `The AI draft for ${field} did not include usable text to apply.` }
+    }
+
+    record[field] = nextValues.items
+    return null
+  }
+
+  if (typeof currentValue === "boolean") {
+    const nextValue = parseDraftBoolean(proposedText)
+    if (nextValue === null) {
+      return { ok: false, error: `The AI draft for ${field} did not include a usable true/false value.` }
+    }
+
+    record[field] = nextValue
+    return null
+  }
+
+  return { ok: false, error: `The AI draft targeted a field that cannot be safely applied: ${field}.` }
+}
+
+export const applyAiDraftChanges = (
+  resumeData: ResumeImportData,
+  changes: AiDraftChange[],
+): ApplyDraftResult => {
+  const nextData: ResumeImportData = structuredClone(resumeData)
+
+  for (const change of changes) {
+    const isRemoveItemChange = Boolean(change.itemId) && !change.field && isRemoveItemDraft(change.proposedText)
+
+    if (isRemoveItemChange) {
+      const sectionValue = (nextData as UnknownRecord)[change.section]
+      if (!Array.isArray(sectionValue)) {
+        return { ok: false, error: `The AI draft targeted an unsupported section: ${change.section}.` }
+      }
+
+      const nextSectionItems = sectionValue.filter(
+        (item) => !(isPlainObject(item) && typeof item.id === "string" && item.id === change.itemId),
+      )
+
+      if (nextSectionItems.length === sectionValue.length) {
+        return {
+          ok: false,
+          error: "The AI draft referenced a resume item that does not exist in local data anymore.",
+        }
+      }
+
+      ;(nextData as UnknownRecord)[change.section] = nextSectionItems
+      continue
+    }
+
+    if (isClearSectionDraft(change)) {
+      const sectionValue = (nextData as UnknownRecord)[change.section]
+      if (!Array.isArray(sectionValue)) {
+        return { ok: false, error: `The AI draft targeted an unsupported section: ${change.section}.` }
+      }
+
+      ;(nextData as UnknownRecord)[change.section] = []
+      continue
+    }
+
+    if (typeof change.proposedText !== "string") {
+      return { ok: false, error: "The AI draft did not include text that can be applied safely." }
+    }
+
+    if (change.section === "personalDetails") {
+      if (!change.field) {
+        return { ok: false, error: "The AI draft did not specify which personal details field to update." }
+      }
+
+      const outcome = assignFieldValue(
+        nextData.personalDetails as UnknownRecord,
+        change.field,
+        change.proposedText,
+      )
+
+      if (outcome) return outcome
+      continue
+    }
+
+    if (change.section === "softSkills") {
+      if (isEmptyListPayload(change.proposedText)) {
+        nextData.softSkills = []
+        continue
+      }
+
+      const nextSoftSkills = parseDraftStringList(change.proposedText)
+      if (!nextSoftSkills.ok) {
+        return {
+          ok: false,
+          error: "The AI draft for softSkills did not include usable text to apply.",
+        }
+      }
+
+      nextData.softSkills = nextSoftSkills.items
+      continue
+    }
+
+    if (change.section === "coreSkills" && !change.itemId && !change.field) {
+      const nextCoreSkill = parseCoreSkillsCreateDraft(change.proposedText)
+      if (!nextCoreSkill) {
+        return {
+          ok: false,
+          error: "The AI draft did not include a valid core skill group to create.",
+        }
+      }
+
+      const hasDuplicateGroup = nextData.coreSkills.some(
+        (item) => item.devLanguage.trim().toLowerCase() === nextCoreSkill.devLanguage.toLowerCase(),
+      )
+
+      if (hasDuplicateGroup) {
+        return {
+          ok: false,
+          error: `A core skill group named ${nextCoreSkill.devLanguage} already exists in local data.`,
+        }
+      }
+
+      nextData.coreSkills = [
+        ...nextData.coreSkills,
+        {
+          id: nanoid(),
+          devLanguage: nextCoreSkill.devLanguage,
+          devFramework: nextCoreSkill.devFramework,
+        },
+      ]
+      continue
+    }
+
+    if (change.section === "personalProjects" && !change.itemId && !change.field) {
+      const nextProject = parsePersonalProjectCreateDraft(change.proposedText)
+      if (!nextProject) {
+        return {
+          ok: false,
+          error: "The AI draft did not include a valid personal project item to create.",
+        }
+      }
+
+      nextData.personalProjects = [
+        ...nextData.personalProjects,
+        {
+          id: nanoid(),
+          projectName: nextProject.projectName,
+          projectSubtitle: nextProject.projectSubtitle,
+          preview: nextProject.preview,
+          briefSummary: nextProject.briefSummary,
+          bulletType: nextProject.bulletType,
+          bulletSummary: nextProject.bulletSummary,
+        },
+      ]
+      continue
+    }
+
+    if (change.section === "workExperiences" && !change.itemId && !change.field) {
+      const nextWorkExperience = parseWorkExperienceCreateDraft(change.proposedText)
+      if (!nextWorkExperience) {
+        return {
+          ok: false,
+          error: "The AI draft did not include a valid work experience item to create.",
+        }
+      }
+
+      nextData.workExperiences = [
+        ...nextData.workExperiences,
+        {
+          id: nanoid(),
+          companyName: nextWorkExperience.companyName,
+          jobTitle: nextWorkExperience.jobTitle,
+          briefSummary: nextWorkExperience.briefSummary,
+          startYear: nextWorkExperience.startYear,
+          endYear: nextWorkExperience.endYear,
+          currentlyHired: nextWorkExperience.currentlyHired,
+          bulletType: nextWorkExperience.bulletType,
+          bulletSummary: nextWorkExperience.bulletSummary,
+        },
+      ]
+      continue
+    }
+
+    if (change.section === "certificates" && !change.itemId && !change.field) {
+      const nextCertificate = parseCertificateCreateDraft(change.proposedText)
+      if (!nextCertificate) {
+        return {
+          ok: false,
+          error: "The AI draft did not include a valid certificate item to create.",
+        }
+      }
+
+      nextData.certificates = [
+        ...nextData.certificates,
+        {
+          id: nanoid(),
+          certificateName: nextCertificate.certificateName,
+          certificateIssuer: nextCertificate.certificateIssuer,
+          yearIssued: nextCertificate.yearIssued,
+          certificateDescription: nextCertificate.certificateDescription,
+        },
+      ]
+      continue
+    }
+
+    if (change.section === "achievements" && !change.itemId && !change.field) {
+      const nextAchievement = parseAchievementCreateDraft(change.proposedText)
+      if (!nextAchievement) {
+        return {
+          ok: false,
+          error: "The AI draft did not include a valid achievement item to create.",
+        }
+      }
+
+      nextData.achievements = [
+        ...nextData.achievements,
+        {
+          id: nanoid(),
+          achievementName: nextAchievement.achievementName,
+          achievementIssuer: nextAchievement.achievementIssuer,
+          yearIssued: nextAchievement.yearIssued,
+          achievementDescription: nextAchievement.achievementDescription,
+        },
+      ]
+      continue
+    }
+
+    const sectionValue = (nextData as UnknownRecord)[change.section]
+    if (!Array.isArray(sectionValue)) {
+      return { ok: false, error: `The AI draft targeted an unsupported section: ${change.section}.` }
+    }
+
+    if (!change.itemId || !change.field) {
+      return {
+        ok: false,
+        error: "The AI draft did not include enough detail to safely update a resume item.",
+      }
+    }
+
+    const targetItem = sectionValue.find((item) =>
+      isPlainObject(item) && typeof item.id === "string" && item.id === change.itemId,
+    )
+
+    if (!isPlainObject(targetItem)) {
+      return {
+        ok: false,
+        error: "The AI draft referenced a resume item that does not exist in local data anymore.",
+      }
+    }
+
+    const outcome = assignFieldValue(targetItem, change.field, change.proposedText)
+    if (outcome) return outcome
+  }
+
+  const sanitizedData = validateImportData(nextData)
+  if (!sanitizedData) {
+    return {
+      ok: false,
+      error: "The confirmed draft could not be validated against the current resume schema.",
+    }
+  }
+
+  return { ok: true, data: sanitizedData }
+}

--- a/src/features/chat-assistant/lib/buildConversationWindow.ts
+++ b/src/features/chat-assistant/lib/buildConversationWindow.ts
@@ -1,0 +1,21 @@
+import type {
+  AiChatConversationMessage,
+  ChatConversationEntry,
+  ChatMessageEntry,
+} from "@/features/chat-assistant/types"
+
+const MAX_CONVERSATION_MESSAGES = 6
+
+const isConversationMessage = (entry: ChatConversationEntry): entry is ChatMessageEntry =>
+  entry.kind === "message" && (entry.role === "user" || entry.role === "assistant")
+
+export const buildConversationWindow = (
+  entries: ChatConversationEntry[],
+): AiChatConversationMessage[] | undefined => {
+  const messages = entries
+    .filter(isConversationMessage)
+    .map(({ role, text }) => ({ role, text }))
+    .slice(-MAX_CONVERSATION_MESSAGES)
+
+  return messages.length ? messages : undefined
+}

--- a/src/features/chat-assistant/lib/fieldLabels.ts
+++ b/src/features/chat-assistant/lib/fieldLabels.ts
@@ -1,0 +1,157 @@
+const CHAT_FIELD_LABELS: Record<string, string> = {
+  fullName: "Full name",
+  jobTitle: "Job title",
+  defaultAddress: "Address",
+  defaultEmail: "Email",
+  defaultPhoneNumber: "Phone number",
+  socialGithub: "GitHub",
+  socialLinkedin: "LinkedIn",
+  summary: "About me",
+  knownLanguages: "Languages",
+  schoolName: "School name",
+  courseDegree: "Degree or course",
+  startYear: "Start date",
+  endYear: "End date",
+  currentEnrolled: "Currently enrolled",
+  companyName: "Company name",
+  briefSummary: "Description",
+  bulletSummary: "Bullet points",
+  bulletType: "Use bullet points",
+  currentlyHired: "Currently employed",
+  projectName: "Project name",
+  projectSubtitle: "Project subtitle",
+  preview: "Project link",
+  certificateName: "Certificate title",
+  certificateIssuer: "Issuer",
+  yearIssued: "Year issued",
+  certificateDescription: "Certificate description",
+  title: "Title",
+  achievementName: "Achievement title",
+  achievementIssuer: "Issuer",
+  achievementDescription: "Achievement description",
+  description: "Description",
+  issuer: "Issuer",
+  year: "Year",
+  devLanguage: "Skill group",
+  devFramework: "Skills",
+  items: "Items",
+}
+
+const CHAT_SECTION_FIELD_LABELS: Record<string, Record<string, string>> = {
+  references: {
+    fullName: "Reference name",
+    jobTitle: "Reference job title",
+    companyName: "Reference company",
+    defaultPhoneNumber: "Reference phone number",
+    defaultEmail: "Reference email",
+  },
+}
+
+const CHAT_SECTION_LABELS: Record<string, string> = {
+  personalDetails: "Personal details",
+  personalProjects: "Personal projects",
+  workExperiences: "Work experience",
+  education: "Education",
+  certificates: "Certificates",
+  achievements: "Achievements",
+  references: "References",
+  coreSkills: "Core skills",
+  softSkills: "Soft skills",
+  knownLanguages: "Languages",
+}
+
+const PLAIN_TEXT_FIELD_REPLACEMENTS = [
+  "fullName",
+  "jobTitle",
+  "briefSummary",
+  "bulletSummary",
+  "bulletType",
+  "knownLanguages",
+  "defaultPhoneNumber",
+  "defaultAddress",
+  "defaultEmail",
+  "socialGithub",
+  "socialLinkedin",
+  "devLanguage",
+  "devFramework",
+  "projectName",
+  "projectSubtitle",
+  "startYear",
+  "endYear",
+  "currentEnrolled",
+  "currentlyHired",
+  "certificateName",
+  "certificateIssuer",
+  "yearIssued",
+  "certificateDescription",
+  "achievementName",
+  "achievementIssuer",
+  "achievementDescription",
+  "courseDegree",
+  "schoolName",
+  "companyName",
+] as const
+
+const humanizeIdentifier = (value: string) =>
+  value
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .trim()
+    .replace(/\b\w/g, (character) => character.toUpperCase())
+
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+
+export const getChatFieldLabel = (field: string | null) => {
+  if (!field) return "Field"
+
+  return CHAT_FIELD_LABELS[field] ?? humanizeIdentifier(field)
+}
+
+export const getChatFieldLabelForSection = (field: string | null, section?: string | null) => {
+  if (!field) return "Field"
+
+  if (section) {
+    const sectionLabel = CHAT_SECTION_FIELD_LABELS[section]?.[field]
+    if (sectionLabel) return sectionLabel
+  }
+
+  return getChatFieldLabel(field)
+}
+
+export const getChatSectionLabel = (section: string | null) => {
+  if (!section) return "Section"
+  return CHAT_SECTION_LABELS[section] ?? humanizeIdentifier(section)
+}
+
+const replaceWholeWord = (text: string, rawValue: string, label: string) =>
+  text.replace(new RegExp(`\\b${escapeRegExp(rawValue)}\\b`, "g"), label)
+
+export const toChatDisplayText = (text: string) => {
+  let nextText = text
+
+  for (const section of Object.keys(CHAT_SECTION_LABELS)) {
+    for (const [field, fieldLabel] of Object.entries(CHAT_FIELD_LABELS)) {
+      nextText = nextText.replace(
+        new RegExp(`\\b${escapeRegExp(section)}\\.${escapeRegExp(field)}\\b`, "g"),
+        CHAT_SECTION_FIELD_LABELS[section]?.[field] ?? fieldLabel,
+      )
+    }
+
+    for (const [field, fieldLabel] of Object.entries(CHAT_SECTION_FIELD_LABELS[section] ?? {})) {
+      nextText = nextText.replace(
+        new RegExp(`\\b${escapeRegExp(section)}\\.${escapeRegExp(field)}\\b`, "g"),
+        fieldLabel,
+      )
+    }
+  }
+
+  for (const [section, sectionLabel] of Object.entries(CHAT_SECTION_LABELS)) {
+    nextText = replaceWholeWord(nextText, section, sectionLabel)
+  }
+
+  for (const field of PLAIN_TEXT_FIELD_REPLACEMENTS) {
+    nextText = replaceWholeWord(nextText, field, CHAT_FIELD_LABELS[field])
+  }
+
+  return nextText
+}

--- a/src/features/chat-assistant/lib/formatDraftPreview.ts
+++ b/src/features/chat-assistant/lib/formatDraftPreview.ts
@@ -1,0 +1,274 @@
+import type { AiDraft, AiDraftChange } from "@/features/chat-assistant/types"
+import { getChatFieldLabelForSection, getChatSectionLabel } from "@/features/chat-assistant/lib/fieldLabels"
+import { parseDraftStringList } from "@/features/chat-assistant/lib/stringListDraft"
+import { parseDraftJsonObject } from "@/features/chat-assistant/lib/structuredDraftJson"
+
+export type DraftPreviewMetadata = string[]
+
+export type DraftPreviewEntry =
+  | {
+      kind: "text"
+      text: string
+      metadata: DraftPreviewMetadata | null
+    }
+  | {
+      kind: "bullets"
+      items: string[]
+      metadata: DraftPreviewMetadata | null
+    }
+  | {
+      kind: "coreSkills"
+      groupName: string
+      skills: string[]
+      metadata: DraftPreviewMetadata | null
+      isNewGroup: boolean
+    }
+  | {
+      kind: "fields"
+      rows: Array<{
+        label: string
+        value: string
+      }>
+      metadata: DraftPreviewMetadata | null
+    }
+
+export type DraftPreview = {
+  entries: DraftPreviewEntry[]
+}
+
+type DraftChangeItemLabelResolver = (change: AiDraftChange) => string | null
+
+const EXCLUDED_STRUCTURED_PREVIEW_FIELDS = new Set([
+  "id",
+  "profilePicture",
+  "configuration",
+  "enableInRender",
+  "template",
+])
+
+const isCoreSkillsCreateChange = (change: AiDraftChange) =>
+  change.section === "coreSkills" &&
+  !change.itemId &&
+  !change.field &&
+  Boolean(change.proposedText?.trim())
+
+const isCoreSkillsUpdateChange = (change: AiDraftChange) =>
+  change.section === "coreSkills" &&
+  Boolean(change.itemId) &&
+  change.field === "devFramework" &&
+  Boolean(change.proposedText?.trim())
+
+const cleanFallbackText = (value: string) =>
+  value
+    .trim()
+    .replace(/^\[\s*/, "")
+    .replace(/\s*\]$/, "")
+    .replace(/^"+|"+$/g, "")
+    .replace(/\\"/g, "\"")
+    .trim()
+
+const looksLikeStructuredObjectText = (value: string) => {
+  const normalized = value.trim()
+
+  return (
+    normalized.startsWith("{") ||
+    normalized.startsWith("\"{") ||
+    normalized.startsWith("\\\"{")
+  )
+}
+
+const parseCoreSkillsDraftPreview = (value: string) => {
+  const parsed = parseDraftJsonObject(value)
+  if (!parsed) return null
+
+  const groupName = typeof parsed.devLanguage === "string" ? parsed.devLanguage.trim() : ""
+  const skills = Array.isArray(parsed.devFramework)
+    ? parsed.devFramework
+        .filter((item): item is string => typeof item === "string")
+        .map((item) => item.trim())
+        .filter(Boolean)
+    : []
+
+  if (!groupName || skills.length === 0) {
+    return null
+  }
+
+  return {
+    groupName,
+    skills,
+  }
+}
+
+const formatStructuredPreviewValue = (value: unknown) => {
+  if (typeof value === "string") {
+    return value.trim() || "Not set yet"
+  }
+
+  if (value === null) {
+    return "Not set yet"
+  }
+
+  if (typeof value === "boolean") {
+    return value ? "Yes" : "No"
+  }
+
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value)
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return "None yet"
+
+    const items = value
+      .filter((item): item is string => typeof item === "string")
+      .map((item) => item.trim())
+      .filter(Boolean)
+
+    if (items.length !== value.length) return null
+    return items.length ? items.join(", ") : "None yet"
+  }
+
+  return null
+}
+
+const formatStructuredFieldsPreview = (value: string, section: string) => {
+  const parsed = parseDraftJsonObject(value)
+  if (!parsed) return null
+
+  const rows = Object.entries(parsed)
+    .filter(([field]) => !EXCLUDED_STRUCTURED_PREVIEW_FIELDS.has(field))
+    .map(([field, fieldValue]) => {
+      const previewValue = formatStructuredPreviewValue(fieldValue)
+      if (!previewValue) return null
+
+      return {
+        label: getChatFieldLabelForSection(field, section),
+        value: previewValue,
+      }
+    })
+    .filter((row): row is { label: string; value: string } => Boolean(row))
+
+  return rows.length ? rows : null
+}
+
+const formatMetadata = (change: AiDraftChange, itemLabel?: string | null) => {
+  const parts = [getChatSectionLabel(change.section)]
+  if (itemLabel?.trim()) parts.push(itemLabel.trim())
+  if (change.field?.trim()) parts.push(getChatFieldLabelForSection(change.field, change.section))
+
+  return parts.length ? parts : null
+}
+
+const formatDraftPreviewEntry = (
+  change: AiDraftChange,
+  draftItemLabel?: string | null,
+  resolveItemLabel?: DraftChangeItemLabelResolver,
+): DraftPreviewEntry | null => {
+  const itemLabel = resolveItemLabel?.(change) ?? draftItemLabel
+  const metadata = formatMetadata(change, itemLabel)
+
+  if (!change.proposedText?.trim()) {
+    return null
+  }
+
+  const proposedText = change.proposedText.trim()
+
+  if (isCoreSkillsCreateChange(change)) {
+    const coreSkillsPreview = parseCoreSkillsDraftPreview(proposedText)
+
+    if (coreSkillsPreview) {
+      return {
+        kind: "coreSkills",
+        groupName: coreSkillsPreview.groupName,
+        skills: coreSkillsPreview.skills,
+        metadata,
+        isNewGroup: true,
+      }
+    }
+  }
+
+  if (isCoreSkillsUpdateChange(change)) {
+    const parsedSkills = parseDraftStringList(proposedText)
+    if (parsedSkills.ok) {
+      return {
+        kind: "coreSkills",
+        groupName: itemLabel?.trim() || "Core skill group",
+        skills: parsedSkills.items,
+        metadata,
+        isNewGroup: false,
+      }
+    }
+  }
+
+  if (change.field === "bulletSummary") {
+    const bulletItems = parseDraftStringList(proposedText)
+
+    if (bulletItems.ok) {
+      return {
+        kind: "bullets",
+        items: [bulletItems.items[bulletItems.items.length - 1]],
+        metadata,
+      }
+    }
+
+    return {
+      kind: "text",
+      text: cleanFallbackText(proposedText),
+      metadata,
+    }
+  }
+
+  if (change.section === "softSkills" || change.field === "knownLanguages") {
+    const listItems = parseDraftStringList(proposedText)
+
+    if (listItems.ok) {
+      return {
+        kind: "fields",
+        rows: [
+          {
+            label: "Items",
+            value: listItems.items.join(", "),
+          },
+        ],
+        metadata,
+      }
+    }
+
+    return {
+      kind: "text",
+      text: cleanFallbackText(proposedText),
+      metadata,
+    }
+  }
+
+  const structuredRows = formatStructuredFieldsPreview(proposedText, change.section)
+  if (structuredRows) {
+    return {
+      kind: "fields",
+      rows: structuredRows,
+      metadata,
+    }
+  }
+
+  if (looksLikeStructuredObjectText(proposedText)) {
+    return null
+  }
+
+  return {
+    kind: "text",
+    text: cleanFallbackText(proposedText),
+    metadata,
+  }
+}
+
+export const formatDraftPreview = (
+  draft: AiDraft,
+  draftItemLabel?: string | null,
+  resolveItemLabel?: DraftChangeItemLabelResolver,
+): DraftPreview | null => {
+  const entries = draft.proposedChanges
+    .map((change) => formatDraftPreviewEntry(change, draftItemLabel, resolveItemLabel))
+    .filter((entry): entry is DraftPreviewEntry => Boolean(entry))
+
+  return entries.length ? { entries } : null
+}

--- a/src/features/chat-assistant/lib/inferPendingAction.ts
+++ b/src/features/chat-assistant/lib/inferPendingAction.ts
@@ -1,0 +1,71 @@
+import type {
+  AiChatResponse,
+  ChatPendingAction,
+  ChatPendingActionType,
+  ChatResumeData,
+} from "@/features/chat-assistant/types"
+
+const CONFIRMATION_PATTERN =
+  /\b(do you want|please confirm|confirm that|are you sure|should i|would you like me)\b/i
+
+const createActionText = (response: AiChatResponse) =>
+  [response.reply, response.clarificationQuestion].filter(Boolean).join(" ")
+
+const classifyPendingAction = (text: string): ChatPendingActionType | null => {
+  if (/\breplace\s+(all|everything)\b|\boverwrite\b/i.test(text)) {
+    return "replace_all"
+  }
+
+  if (/\b(delete|remove|clear)\b/i.test(text)) {
+    return "delete"
+  }
+
+  if (/\b(destructive|permanent|permanently|cannot be undone|can't be undone)\b/i.test(text)) {
+    return "destructive_edit"
+  }
+
+  return CONFIRMATION_PATTERN.test(text) ? "clarification" : null
+}
+
+const getSectionItemIds = (
+  resumeData: ChatResumeData,
+  section: string,
+): string[] => {
+  const value = resumeData[section as keyof ChatResumeData]
+  if (!Array.isArray(value)) return []
+
+  return value
+    .map((item) => {
+      if (typeof item !== "object" || item === null) return null
+      const candidate = item as { id?: unknown }
+      return typeof candidate.id === "string" && candidate.id.trim()
+        ? candidate.id
+        : null
+    })
+    .filter((id): id is string => Boolean(id))
+}
+
+export const inferPendingAction = (
+  response: AiChatResponse,
+  resumeData: ChatResumeData,
+): ChatPendingAction | null => {
+  if (response.draft !== null || !response.target.section) return null
+
+  const text = createActionText(response)
+  if (!CONFIRMATION_PATTERN.test(text)) return null
+
+  const type = classifyPendingAction(text)
+  if (!type) return null
+
+  const targetItemIds = response.target.itemId
+    ? [response.target.itemId]
+    : type === "delete" && response.target.scope === "section"
+      ? getSectionItemIds(resumeData, response.target.section)
+      : []
+
+  return {
+    type,
+    targetSection: response.target.section,
+    ...(targetItemIds.length ? { targetItemIds } : {}),
+  }
+}

--- a/src/features/chat-assistant/lib/parseChatUserDecision.ts
+++ b/src/features/chat-assistant/lib/parseChatUserDecision.ts
@@ -1,0 +1,30 @@
+import type { ChatUserDecision } from "@/features/chat-assistant/types"
+
+const normalizeDecisionText = (message: string) =>
+  message
+    .trim()
+    .toLowerCase()
+    .replace(/[’`]/g, "'")
+    .replace(/[.!?]+$/g, "")
+    .replace(/\s+/g, " ")
+
+export const parseChatUserDecision = (message: string): ChatUserDecision | null => {
+  const text = normalizeDecisionText(message)
+  if (!text) return null
+
+  if (
+    /^(no|n|cancel|stop|reject)$/.test(text) ||
+    /\b(never mind|do not|don't)\b/.test(text)
+  ) {
+    return "reject"
+  }
+
+  if (
+    /^(yes|y|confirm|confirmed|proceed)$/.test(text) ||
+    /\b(go ahead|do it)\b/.test(text)
+  ) {
+    return "confirm"
+  }
+
+  return null
+}

--- a/src/features/chat-assistant/lib/resolveTargetItemLabel.ts
+++ b/src/features/chat-assistant/lib/resolveTargetItemLabel.ts
@@ -1,0 +1,52 @@
+import type { ResumeImportData } from "@/entities/resume/types"
+import type { AiChatResponse } from "@/features/chat-assistant/types"
+
+type TargetLabelResumeData = Pick<
+  ResumeImportData,
+  | "personalProjects"
+  | "workExperiences"
+  | "education"
+  | "certificates"
+  | "achievements"
+  | "references"
+  | "coreSkills"
+>
+
+export const resolveTargetItemLabel = (
+  target: AiChatResponse["target"],
+  resumeData: TargetLabelResumeData,
+) => {
+  if (!target.itemId || !target.section) return null
+
+  const { itemId, section } = target
+
+  if (section === "personalProjects") {
+    return resumeData.personalProjects.find((item) => item.id === itemId)?.projectName ?? null
+  }
+
+  if (section === "workExperiences") {
+    return resumeData.workExperiences.find((item) => item.id === itemId)?.companyName ?? null
+  }
+
+  if (section === "education") {
+    return resumeData.education.find((item) => item.id === itemId)?.schoolName ?? null
+  }
+
+  if (section === "certificates") {
+    return resumeData.certificates.find((item) => item.id === itemId)?.certificateName ?? null
+  }
+
+  if (section === "achievements") {
+    return resumeData.achievements.find((item) => item.id === itemId)?.achievementName ?? null
+  }
+
+  if (section === "references") {
+    return resumeData.references.find((item) => item.id === itemId)?.fullName ?? null
+  }
+
+  if (section === "coreSkills") {
+    return resumeData.coreSkills.find((item) => item.id === itemId)?.devLanguage ?? null
+  }
+
+  return null
+}

--- a/src/features/chat-assistant/lib/resumePayload.ts
+++ b/src/features/chat-assistant/lib/resumePayload.ts
@@ -1,0 +1,21 @@
+import { createResumeImportData } from "@/entities/resume/lib/importExport"
+import type { ResumeData } from "@/entities/resume/types"
+import type { ChatResumeData } from "@/features/chat-assistant/types"
+
+export const createChatResumeData = (resumeData: ResumeData): ChatResumeData => {
+  const snapshot = createResumeImportData(resumeData)
+  const {
+    activePage: _activePage,
+    configuration: _configuration,
+    enableInRender: _enableInRender,
+    template: _template,
+    personalDetails,
+    ...rest
+  } = snapshot
+  const { profilePicture: _profilePicture, ...safePersonalDetails } = personalDetails
+
+  return {
+    ...rest,
+    personalDetails: safePersonalDetails,
+  }
+}

--- a/src/features/chat-assistant/lib/stringListDraft.ts
+++ b/src/features/chat-assistant/lib/stringListDraft.ts
@@ -1,0 +1,63 @@
+export type StringListDraftParseResult =
+  | { ok: true; items: string[] }
+  | { ok: false }
+
+const BULLET_PREFIX_PATTERN = /^(?:[-*•]+|\d+[.)])\s*/
+
+export const normalizeDraftListItem = (value: string) =>
+  value.trim().replace(BULLET_PREFIX_PATTERN, "").trim().replace(/\s+/g, " ")
+
+export const dedupeDraftListItems = (items: string[]) => {
+  const seen = new Set<string>()
+
+  return items.filter((item) => {
+    const normalized = item.toLowerCase()
+    if (seen.has(normalized)) return false
+    seen.add(normalized)
+    return true
+  })
+}
+
+export const parseDraftStringList = (value: string): StringListDraftParseResult => {
+  const trimmed = value.trim()
+  if (!trimmed) return { ok: false }
+
+  if (trimmed.startsWith("[")) {
+    try {
+      const parsed = JSON.parse(trimmed) as unknown
+
+      if (!Array.isArray(parsed) || !parsed.every((item) => typeof item === "string")) {
+        return { ok: false }
+      }
+
+      const items = dedupeDraftListItems(
+        parsed
+          .map(normalizeDraftListItem)
+          .filter(Boolean),
+      )
+
+      return items.length ? { ok: true, items } : { ok: false }
+    } catch {
+      return { ok: false }
+    }
+  }
+
+  const lines = trimmed
+    .split(/\r?\n+/)
+    .map(normalizeDraftListItem)
+    .filter(Boolean)
+
+  if (lines.length > 1) {
+    return { ok: true, items: dedupeDraftListItems(lines) }
+  }
+
+  const inlineBulletItems = trimmed
+    .split(/(?=\s*(?:[-*•]+|\d+[.)])\s+)/)
+    .map(normalizeDraftListItem)
+    .filter(Boolean)
+
+  const fallbackItems = inlineBulletItems.length > 1 ? inlineBulletItems : lines
+  const items = dedupeDraftListItems(fallbackItems)
+
+  return items.length ? { ok: true, items } : { ok: false }
+}

--- a/src/features/chat-assistant/lib/structuredDraftJson.ts
+++ b/src/features/chat-assistant/lib/structuredDraftJson.ts
@@ -1,0 +1,33 @@
+type UnknownRecord = Record<string, unknown>
+
+const isPlainObject = (value: unknown): value is UnknownRecord =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const parseJsonCandidate = (value: string): unknown => {
+  try {
+    return JSON.parse(value) as unknown
+  } catch {
+    return null
+  }
+}
+
+const unwrapParsedJson = (value: unknown): UnknownRecord | null => {
+  if (isPlainObject(value)) return value
+  if (typeof value !== "string") return null
+
+  const reparsed = parseJsonCandidate(value)
+  return isPlainObject(reparsed) ? reparsed : null
+}
+
+export const parseDraftJsonObject = (value: string): UnknownRecord | null => {
+  const normalized = value.trim()
+  if (!normalized) return null
+
+  const parsed = unwrapParsedJson(parseJsonCandidate(normalized))
+  if (parsed) return parsed
+
+  const unescaped = normalized.replace(/\\"/g, "\"")
+  if (unescaped === normalized) return null
+
+  return unwrapParsedJson(parseJsonCandidate(unescaped))
+}

--- a/src/features/chat-assistant/store/useChatAssistantStore.ts
+++ b/src/features/chat-assistant/store/useChatAssistantStore.ts
@@ -1,0 +1,94 @@
+import { nanoid } from "nanoid"
+import { create } from "zustand"
+import { createJSONStorage, persist } from "zustand/middleware"
+import localforage from "@/shared/lib/localForage"
+import type {
+  ChatActionableDraft,
+  ChatClarificationState,
+  ChatConversationEntry,
+  ChatMessageRole,
+  ChatNoticeVariant,
+  ChatPendingAction,
+} from "@/features/chat-assistant/types"
+
+type ChatAssistantStore = {
+  hasHydrated: boolean
+  entries: ChatConversationEntry[]
+  activeDraft: ChatActionableDraft | null
+  activeClarification: ChatClarificationState | null
+  pendingAction: ChatPendingAction | null
+  lastUserMessage: string | null
+  pending: boolean
+  setHasHydrated: () => void
+  appendMessage: (role: ChatMessageRole, text: string) => void
+  appendNotice: (variant: ChatNoticeVariant, text: string) => void
+  setActiveDraft: (draft: ChatActionableDraft | null) => void
+  setActiveClarification: (clarification: ChatClarificationState | null) => void
+  setPendingAction: (pendingAction: ChatPendingAction | null) => void
+  setLastUserMessage: (message: string | null) => void
+  setPending: (value: boolean) => void
+  clearConversation: () => void
+}
+
+type PersistedChatAssistantState = Pick<
+  ChatAssistantStore,
+  "entries" | "activeDraft" | "activeClarification" | "pendingAction" | "lastUserMessage"
+>
+
+export const useChatAssistantStore = create<ChatAssistantStore>()(
+  persist(
+    (set) => ({
+      hasHydrated: false,
+      entries: [],
+      activeDraft: null,
+      activeClarification: null,
+      pendingAction: null,
+      lastUserMessage: null,
+      pending: false,
+      setHasHydrated: () => set({ hasHydrated: true }),
+      appendMessage: (role, text) =>
+        set((state) => ({
+          entries: [
+            ...state.entries,
+            { id: nanoid(), kind: "message", role, text },
+          ],
+        })),
+      appendNotice: (variant, text) =>
+        set((state) => ({
+          entries: [
+            ...state.entries,
+            { id: nanoid(), kind: "notice", variant, text },
+          ],
+        })),
+      setActiveDraft: (activeDraft) => set({ activeDraft }),
+      setActiveClarification: (activeClarification) => set({ activeClarification }),
+      setPendingAction: (pendingAction) => set({ pendingAction }),
+      setLastUserMessage: (lastUserMessage) => set({ lastUserMessage }),
+      setPending: (pending) => set({ pending }),
+      clearConversation: () =>
+        set({
+          entries: [],
+          activeDraft: null,
+          activeClarification: null,
+          pendingAction: null,
+          lastUserMessage: null,
+          pending: false,
+        }),
+    }),
+    {
+      name: "chatAssistantData",
+      storage: createJSONStorage(() => localforage),
+      partialize: (state): PersistedChatAssistantState => ({
+        entries: state.entries,
+        activeDraft: state.activeDraft,
+        activeClarification: state.activeClarification,
+        pendingAction: state.pendingAction,
+        lastUserMessage: state.lastUserMessage,
+      }),
+      onRehydrateStorage: () => (state) => {
+        state?.setHasHydrated()
+        state?.setPending(false)
+      },
+    },
+  ),
+)

--- a/src/features/chat-assistant/types.ts
+++ b/src/features/chat-assistant/types.ts
@@ -1,0 +1,122 @@
+import type { ResumeImportData } from "@/entities/resume/types"
+
+export type AiProviderName = "pollinations" | "llama"
+
+export type AiChatMode =
+  | "exact_edit"
+  | "grounded_suggestion"
+  | "role_targeted_suggestion"
+
+export type AiResponseStatus =
+  | "clarification_needed"
+  | "draft_ready"
+  | "awaiting_confirmation"
+  | "blocked"
+
+export type AiTargetScope = "single_item" | "section" | "resume_wide" | "unknown"
+
+export type AiDraftChange = {
+  section: string
+  itemId: string | null
+  field: string | null
+  instruction: string
+  proposedText: string | null
+}
+
+export type AiDraft = {
+  summary: string
+  proposedChanges: AiDraftChange[]
+}
+
+export type AiChatTarget = {
+  section: string | null
+  itemId: string | null
+  field: string | null
+  scope: AiTargetScope
+}
+
+export type AiChatResponse = {
+  provider: AiProviderName
+  mode: AiChatMode
+  reply: string
+  status: AiResponseStatus
+  clarificationQuestion: string | null
+  needsClarification: boolean
+  needsConfirmation: boolean
+  readyToApply: boolean
+  target: AiChatTarget
+  draft: AiDraft | null
+  warnings: string[]
+}
+
+export type ChatResumeData = Omit<
+  ResumeImportData,
+  "activePage" | "configuration" | "enableInRender" | "template" | "personalDetails"
+> & {
+  personalDetails: Omit<ResumeImportData["personalDetails"], "profilePicture">
+}
+
+export type ChatMessageRole = "user" | "assistant"
+
+export type AiChatConversationMessage = {
+  role: ChatMessageRole
+  text: string
+}
+
+export type AiActiveDraft = {
+  mode: AiChatMode
+  target: AiChatTarget
+  draft: AiDraft
+}
+
+export type ChatPendingActionType =
+  | "delete"
+  | "replace_all"
+  | "destructive_edit"
+  | "clarification"
+
+export type ChatPendingAction = {
+  type: ChatPendingActionType
+  targetSection: string | null
+  targetItemIds?: string[]
+}
+
+export type ChatUserDecision = "confirm" | "reject"
+
+export type AiChatRequest = {
+  message: string
+  resumeData: ChatResumeData
+  conversation?: AiChatConversationMessage[]
+  activeDraft?: AiActiveDraft | null
+  pendingAction?: ChatPendingAction
+  userDecision?: ChatUserDecision
+}
+
+export type ChatMessageEntry = {
+  id: string
+  kind: "message"
+  role: ChatMessageRole
+  text: string
+}
+
+export type ChatNoticeVariant = "error" | "warning"
+
+export type ChatNoticeEntry = {
+  id: string
+  kind: "notice"
+  variant: ChatNoticeVariant
+  text: string
+}
+
+export type ChatConversationEntry = ChatMessageEntry | ChatNoticeEntry
+
+export type ChatActionableDraft = {
+  requestMessage: string
+  mode: AiChatMode
+  draft: AiDraft
+  target: AiChatTarget
+}
+
+export type ChatClarificationState = {
+  question: string
+}

--- a/src/features/editor/hooks/useConfiguration.ts
+++ b/src/features/editor/hooks/useConfiguration.ts
@@ -1,4 +1,4 @@
-import type { ChangeEvent } from "react"
+import { useState, type ChangeEvent } from "react"
 import type { Configuration, TemplateConfig } from "@/entities/resume/types"
 import { useInterfaceStore } from "@/shared/store/useInterfaceStore"
 import { useResumeStore } from "@/entities/resume/store/useResumeStore"
@@ -14,7 +14,37 @@ type TemplateNumberKey<K extends keyof TemplateConfig> = {
     [Key in keyof TemplateConfig[K]]: TemplateConfig[K][Key] extends number ? Key : never
 }[keyof TemplateConfig[K]]
 
+const hasText = (value: unknown) => typeof value === "string" && value.trim().length > 0
+
+const hasExistingResumeContent = () => {
+    const state = useResumeStore.getState()
+    const details = state.personalDetails
+
+    return (
+        hasText(details.fullName) ||
+        hasText(details.jobTitle) ||
+        hasText(details.defaultAddress) ||
+        hasText(details.defaultEmail) ||
+        hasText(details.defaultPhoneNumber) ||
+        hasText(details.socialGithub) ||
+        hasText(details.socialLinkedin) ||
+        hasText(details.summary) ||
+        hasText(details.profilePicture) ||
+        details.knownLanguages.length > 0 ||
+        state.education.length > 0 ||
+        state.references.length > 0 ||
+        state.softSkills.length > 0 ||
+        state.coreSkills.length > 0 ||
+        state.workExperiences.length > 0 ||
+        state.personalProjects.length > 0 ||
+        state.certificates.length > 0 ||
+        state.achievements.length > 0
+    )
+}
+
 export function useConfigurationHook() {
+    const [isImporting, setIsImporting] = useState(false)
+    const [pendingImportFile, setPendingImportFile] = useState<File | null>(null)
     const toNumber = (value: unknown) => {
         if (typeof value === "number") return value
         if (typeof value === "string" && value.trim()) return Number(value)
@@ -81,13 +111,12 @@ export function useConfigurationHook() {
         URL.revokeObjectURL(url)
     }
 
-    const importData = (event: ChangeEvent<HTMLInputElement>) => {
-        const input = event.target
-        const file = event.target.files?.[0]
-        if (!file) return
+    const readImportFile = (file: File) => {
+        setIsImporting(true)
         if (!isJsonFile(file) || file.size > MAX_IMPORT_SIZE_BYTES) {
             setDataStatus(false)
-            input.value = ""
+            setIsImporting(false)
+            setPendingImportFile(null)
             return
         }
 
@@ -99,7 +128,6 @@ export function useConfigurationHook() {
 
                 if (!sanitized) {
                     setDataStatus(false)
-                    input.value = ""
                     return
                 }
 
@@ -108,10 +136,39 @@ export function useConfigurationHook() {
             } catch {
                 setDataStatus(false)
             } finally {
-                input.value = ""
+                setIsImporting(false)
+                setPendingImportFile(null)
             }
         }
+        reader.onerror = () => {
+            setDataStatus(false)
+            setIsImporting(false)
+            setPendingImportFile(null)
+        }
         reader.readAsText(file)
+    }
+
+    const importData = (event: ChangeEvent<HTMLInputElement>) => {
+        const input = event.target
+        const file = event.target.files?.[0]
+        if (!file) return
+        input.value = ""
+
+        if (hasExistingResumeContent()) {
+            setPendingImportFile(file)
+            return
+        }
+
+        readImportFile(file)
+    }
+
+    const confirmImportData = () => {
+        if (!pendingImportFile) return
+        readImportFile(pendingImportFile)
+    }
+
+    const cancelImportData = () => {
+        setPendingImportFile(null)
     }
 
     return {
@@ -126,6 +183,10 @@ export function useConfigurationHook() {
         reset,
         importData,
         exportData,
+        isImporting,
+        hasPendingImport: pendingImportFile !== null,
+        confirmImportData,
+        cancelImportData,
         updateNumberConfig,
         updateTemplateNumber,
     }

--- a/src/features/editor/panels/DataPanel.tsx
+++ b/src/features/editor/panels/DataPanel.tsx
@@ -1,25 +1,84 @@
 import {
     ArrowDownCircleIcon,
     CheckCircleIcon,
+    ExclamationTriangleIcon,
     InformationCircleIcon,
     XCircleIcon
 } from "@heroicons/react/24/outline"
 import { useConfigurationHook } from "@/features/editor/hooks/useConfiguration"
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 import Alert from "@/shared/ui/Alert"
 import Button from "@/shared/ui/Button"
 import Input from "@/shared/ui/Input"
 import EditorSection from "@/shared/ui/EditorSection"
+import Modal from "@/shared/ui/Modal"
 
 export default function DataPanel() {
-    const { dataStatus, setDataStatus, importData, exportData } = useConfigurationHook()
+    const {
+        dataStatus,
+        setDataStatus,
+        importData,
+        exportData,
+        isImporting,
+        hasPendingImport,
+        confirmImportData,
+        cancelImportData,
+    } = useConfigurationHook()
+    const importWarningRef = useRef<HTMLDialogElement>(null)
 
     useEffect(() => {
         setDataStatus(null)
     }, [setDataStatus])
 
+    useEffect(() => {
+        if (hasPendingImport) {
+            importWarningRef.current?.showModal()
+        } else {
+            importWarningRef.current?.close()
+        }
+    }, [hasPendingImport])
+
     return (
         <EditorSection title="Transfer data">
+            <Modal
+                ref={importWarningRef}
+                size="md"
+                onCancel={cancelImportData}
+                content={
+                    <div className="space-y-4">
+                        <div className="flex items-start gap-3">
+                            <div className="mt-1 flex size-10 shrink-0 items-center justify-center rounded-full border border-warning/28 bg-warning/12 text-warning">
+                                <ExclamationTriangleIcon className="size-5" />
+                            </div>
+                            <div className="min-w-0">
+                                <h3 className="font-manrope text-lg font-semibold text-slate-100">Replace current resume data?</h3>
+                                <p className="mt-2 text-sm leading-6 text-slate-300">
+                                    You already have resume information saved in this browser. Importing this JSON file will replace the current data.
+                                </p>
+                            </div>
+                        </div>
+                        <div className="rounded-[0.4rem] border border-sky-300/18 bg-sky-400/8 px-4 py-3 text-sm leading-6 text-slate-300">
+                            I recommend downloading your current data first so you have a backup before continuing.
+                        </div>
+                    </div>
+                }
+                actions={
+                    <>
+                        <Button
+                            text="Cancel"
+                            variant="transparent"
+                            onClick={cancelImportData}
+                        />
+                        <Button
+                            text="Proceed with import"
+                            variant="warning"
+                            onClick={confirmImportData}
+                            isDisabled={isImporting}
+                        />
+                    </>
+                }
+            />
+
             <div className="editor-subtle-panel flex flex-col gap-3">
                 <Button
                     text="Download your data"
@@ -38,7 +97,7 @@ export default function DataPanel() {
             </div>
 
             <div className="editor-subtle-panel flex flex-col gap-3">
-                <Input type="file" accept="json" onChange={importData} noPadding={true} isStretch={true} />
+                <Input type="file" accept="json" onChange={importData} noPadding={true} isStretch={true} isDisabled={isImporting} />
                 {dataStatus === null && (
                     <div className="flex items-start gap-2 text-sm leading-6 text-slate-400">
                         <InformationCircleIcon className="size-5 shrink-0" />

--- a/src/features/editor/panels/ModernSectionLayout.tsx
+++ b/src/features/editor/panels/ModernSectionLayout.tsx
@@ -76,7 +76,7 @@ function SortableSectionItem({ id, container, onMove }: SortableSectionItemProps
             {...attributes}
             {...listeners}
             className={clsx(
-                "flex min-w-0 cursor-grab flex-row items-start gap-3 rounded-[0.35rem] border border-base-300/70 bg-base-200/55 px-3 py-2 active:cursor-grabbing",
+                "flex min-w-0 cursor-grab flex-row items-start gap-3 rounded-[0.35rem] border border-slate-500/30 bg-slate-800/58 px-3 py-2 active:cursor-grabbing",
                 isDragging ? "opacity-80" : "opacity-100",
             )}
         >
@@ -88,7 +88,7 @@ function SortableSectionItem({ id, container, onMove }: SortableSectionItemProps
             </span>
             <button
                 type="button"
-                className="ml-auto shrink-0 rounded-[0.25rem] border border-base-300 px-2 py-1 text-[11px] font-medium text-slate-200 hover:border-primary/45 hover:text-slate-50"
+                className="ml-auto shrink-0 rounded-[0.25rem] border border-slate-500/38 bg-slate-900/30 px-2 py-1 text-[11px] font-medium text-slate-200 hover:border-primary/45 hover:text-slate-50"
                 onPointerDown={(event) => event.stopPropagation()}
                 onMouseDown={(event) => event.stopPropagation()}
                 onClick={(event) => {
@@ -118,7 +118,7 @@ function SectionColumn({ container, label, items, onMove }: SectionColumnProps) 
             <div
                 ref={setNodeRef}
                 data-testid={`modern-${container}-sections`}
-                className={clsx("space-y-2 rounded-[0.35rem] border border-base-300/60 bg-base-200/25 p-2", isOver && "bg-base-200/55")}
+                className={clsx("space-y-2 rounded-[0.35rem] border border-slate-500/34 bg-slate-900/28 p-2", isOver && "bg-slate-800/56")}
             >
                 <SortableContext items={items} strategy={verticalListSortingStrategy}>
                     <div className="space-y-2">
@@ -268,7 +268,7 @@ export default function ModernSectionLayout() {
     }
 
     return (
-        <fieldset className="fieldset rounded-[0.35rem] border border-base-300/70 p-3 md:h-full" aria-label="Section layout">
+        <fieldset className="fieldset rounded-[0.35rem] border border-slate-500/38 bg-slate-900/20 p-3 md:h-full" aria-label="Section layout">
             <legend className="fieldset-legend text-xs font-medium uppercase tracking-[0.18em] text-slate-400">Section layout</legend>
             <span className="text-xs text-slate-400">
                 Drag sections between the sidebar and the main content area, or use the move action inside each row.

--- a/src/features/editor/panels/ResetPanel.tsx
+++ b/src/features/editor/panels/ResetPanel.tsx
@@ -10,7 +10,7 @@ export default function ResetPanel() {
             <div className="flex flex-col gap-1">
                 <Button
                     variant="danger"
-                    text="Reset everything"
+                    text="Reset"
                     icon={<TrashIcon className="size-5" />}
                     onClick={() => {
                         const dialog = document.getElementById(id) as HTMLDialogElement | null

--- a/src/features/editor/panels/TemplatePanel.tsx
+++ b/src/features/editor/panels/TemplatePanel.tsx
@@ -136,14 +136,14 @@ export default function TemplatePanel() {
                                 <label className="fieldset-legend text-xs font-medium uppercase tracking-[0.18em] text-slate-400" htmlFor="template-color">
                                     {colorField.label}
                                 </label>
-                                <div className="flex flex-wrap items-center gap-3 rounded-[0.35rem] border border-base-300 bg-base-200/65 px-3 py-3">
+                                <div className="flex flex-wrap items-center gap-3 rounded-[0.35rem] border border-slate-500/38 bg-slate-900/42 px-3 py-3">
                                     <input
                                         id="template-color"
                                         type="color"
                                         aria-label={colorField.label}
                                         value={colorField.value}
                                         onChange={event => colorField.onChange(event.target.value)}
-                                        className="h-10 w-14 shrink-0 cursor-pointer rounded-[0.25rem] border border-base-300 bg-transparent p-1"
+                                        className="h-10 w-14 shrink-0 cursor-pointer rounded-[0.25rem] border border-slate-500/38 bg-slate-900/42 p-1"
                                     />
                                     <div className="min-w-0 flex-1">
                                         <div className="text-[11px] uppercase tracking-[0.18em] text-slate-400">Selected</div>

--- a/src/features/editor/panels/TemplateSectionOrder.tsx
+++ b/src/features/editor/panels/TemplateSectionOrder.tsx
@@ -47,7 +47,7 @@ function SectionOrderItem({ id, label, isEnabled, onToggle }: SectionOrderItemPr
             ref={setNodeRef}
             style={style}
             className={clsx(
-                "flex flex-row items-center gap-3 rounded-[0.35rem] border border-base-300/70 bg-base-200/55 px-3 py-2",
+                "flex flex-row items-center gap-3 rounded-[0.35rem] border border-slate-500/30 bg-slate-800/58 px-3 py-2 shadow-[inset_0_1px_0_rgba(148,163,184,0.04)]",
                 isDragging ? "opacity-80" : "opacity-100",
             )}
         >
@@ -58,7 +58,7 @@ function SectionOrderItem({ id, label, isEnabled, onToggle }: SectionOrderItemPr
             >
                 <Bars3Icon className="size-5" />
             </div>
-            <span className="text-sm font-medium text-slate-200">{label}</span>
+            <span className="text-sm font-medium text-slate-100">{label}</span>
             <div className="ml-auto">
                 <input
                     type="checkbox"
@@ -96,7 +96,7 @@ export default function TemplateSectionOrder({ templateId }: TemplateSectionOrde
     }
 
     return (
-        <fieldset className="fieldset rounded-[0.45rem] border border-slate-500/36 bg-base-200/22 p-4 md:h-full">
+        <fieldset className="fieldset rounded-[0.45rem] border border-slate-500/48 bg-slate-800/34 p-4 md:h-full">
             <legend className="fieldset-legend px-1 text-sm font-semibold uppercase tracking-[0.18em] text-slate-200">Modify components</legend>
             <span className="text-sm text-slate-400">Drag to reorder and toggle to enable.</span>
 

--- a/src/features/editor/tabs/Configuration.tsx
+++ b/src/features/editor/tabs/Configuration.tsx
@@ -1,6 +1,50 @@
 import EditorSection from "@/shared/ui/EditorSection"
 import PagePanel from "@/features/editor/panels/PagePanel"
 import TemplatePanel from "@/features/editor/panels/TemplatePanel"
+import { useConfigurationHook } from "@/features/editor/hooks/useConfiguration"
+import Input from "@/shared/ui/Input"
+
+const POLLINATIONS_KEY_PATTERN = "^(sk|pk)_[A-Za-z0-9]{32}$"
+const isPollinationsKeyValid = (value: string) =>
+    !value.trim() || /^(sk|pk)_[A-Za-z0-9]{32}$/.test(value.trim())
+
+function AssistantPanel() {
+    const { config, updateConfig } = useConfigurationHook()
+    const isKeyValid = isPollinationsKeyValid(config.pollinationsApiKey)
+
+    return (
+        <div className="editor-subtle-panel space-y-3 p-4">
+            <Input
+                label="Pollinations API key"
+                value={config.pollinationsApiKey}
+                placeholder="sk_00000000000000000000000000000000"
+                maxLength={35}
+                pattern={POLLINATIONS_KEY_PATTERN}
+                autoComplete="off"
+                onChange={(event) => updateConfig("pollinationsApiKey", event.target.value.replace(/\s/g, ""))}
+                isStretch={true}
+                noPadding={true}
+            />
+            {!isKeyValid ? (
+                <p className="text-sm leading-6 text-error">
+                    Use sk_ or pk_ followed by 32 alphanumeric characters.
+                </p>
+            ) : null}
+            <p className="text-sm leading-6 text-slate-400">
+                Optional. Get your Pollinations key at{" "}
+                <a
+                    href="https://enter.pollinations.ai"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="font-medium text-sky-200 underline-offset-4 transition-colors duration-150 hover:text-sky-100 hover:underline"
+                >
+                    enter.pollinations.ai
+                </a>
+                .
+            </p>
+        </div>
+    )
+}
 
 export default function Configuration() {
 
@@ -12,6 +56,10 @@ export default function Configuration() {
 
             <EditorSection title="Page">
                 <PagePanel />
+            </EditorSection>
+
+            <EditorSection title="Assistant">
+                <AssistantPanel />
             </EditorSection>
         </div>
     )

--- a/src/features/multiselect/MultiSelect.tsx
+++ b/src/features/multiselect/MultiSelect.tsx
@@ -197,22 +197,22 @@ export default function MultiSelect({
                 getOptionValue={(option) => option.label}
                 getOptionLabel={(option) => option.label}
                 classNames={{
-                    control: () => "editor-control flex min-h-11 w-full items-center gap-2 rounded-[var(--radius-field)] border-slate-500/55 px-3",
+                    control: () => "editor-control flex min-h-11 w-full items-stretch gap-2 rounded-[var(--radius-field)] px-3 py-2",
                     placeholder: () => "m-0 text-sm leading-none text-slate-500",
-                    valueContainer: () => "flex min-h-11 flex-1 flex-wrap content-center items-center gap-1 py-0",
+                    valueContainer: () => "flex min-h-8 flex-1 flex-wrap content-center items-center gap-1.5 py-0",
                     input: () => "m-0 p-0 text-sm leading-none text-slate-100",
                     singleValue: () => "m-0 text-sm leading-none text-slate-100",
-                    multiValue: () => "flex items-center gap-1 rounded-[0.2rem] bg-primary/18 px-2 py-0.5",
+                    multiValue: () => "flex items-center gap-1 rounded-[0.2rem] bg-sky-300/16 px-2 py-0.5 ring-1 ring-sky-200/10",
                     multiValueLabel: () => "text-xs text-slate-100",
                     multiValueRemove: () => "cursor-pointer text-slate-100 hover:bg-transparent",
-                    menu: () => "mt-1 w-full rounded-[var(--radius-field)] border border-slate-500/55 bg-base-200 shadow-xl",
+                    menu: () => "mt-1 w-full rounded-[var(--radius-field)] border border-slate-500/38 bg-slate-900/96 shadow-xl backdrop-blur-xl",
                     option: ({ isFocused }) =>
                         clsx(
                             "cursor-pointer px-3 py-1.5 text-sm",
                             isFocused && "bg-primary/18 text-slate-100",
                         ),
-                    noOptionsMessage: () => "rounded-[var(--radius-field)] border border-dashed border-slate-500/55 bg-base-200 px-3 py-2 text-sm text-slate-500",
-                    indicatorsContainer: () => "flex h-11 shrink-0 items-center justify-center self-stretch border-l border-slate-500/55 pl-2",
+                    noOptionsMessage: () => "rounded-[var(--radius-field)] border border-dashed border-slate-500/38 bg-slate-900/55 px-3 py-2 text-sm text-slate-500",
+                    indicatorsContainer: () => "flex min-h-8 shrink-0 items-center justify-center self-stretch border-l border-slate-500/34 pl-2",
                     clearIndicator: () => "p-1 text-slate-400 hover:text-error",
                     dropdownIndicator: ({ isFocused }) =>
                         clsx(

--- a/src/features/sortable/Item.tsx
+++ b/src/features/sortable/Item.tsx
@@ -121,63 +121,53 @@ export default function SortableItem({
             data-state={isRemoving ? "removing" : isActiveDrag ? "dragging" : "idle"}
             data-drop-position={dropPosition ?? "none"}
             className={clsx(
-                "relative grid gap-4 rounded-[0.45rem] border border-slate-500/24 bg-base-200/30 px-3 py-3 transition-[transform,border-color,box-shadow,background-color,opacity] duration-180 sm:grid-cols-[2.25rem_minmax(0,1fr)]",
+                "relative rounded-[0.45rem] border border-slate-500/24 bg-base-200/30 px-3 py-3 transition-[transform,border-color,box-shadow,background-color,opacity] duration-180",
                 isFadeIn && "editor-item-enter",
                 isRemoving && "editor-item-removing",
                 isActiveDrag && "z-30 border-sky-300/38 bg-slate-800/86 shadow-[0_22px_46px_rgba(2,6,23,0.38)]",
-                dropPosition && "bg-base-200/42",
             )}
         >
-            <div
-                aria-hidden="true"
-                className={clsx(
-                    "pointer-events-none absolute left-12 right-3 h-[2px] rounded-full bg-sky-300/88 opacity-0 shadow-[0_0_18px_rgba(56,189,248,0.22)] transition-opacity duration-150",
-                    dropPosition === "before" && "top-1.5 opacity-100",
-                    dropPosition === "after" && "bottom-1.5 opacity-100",
-                )}
-            />
-
-            <div className="flex flex-col items-center gap-2 pt-0.5">
+            <div className="flex min-w-0 items-start gap-3">
                 <div
                     ref={setActivatorNodeRef}
                     {...attributes}
                     {...listeners}
                     data-testid="sortable-handle"
                     aria-label="Drag item"
-                    className="flex h-8 w-8 cursor-grab touch-none items-center justify-center rounded-[0.35rem] text-slate-400 transition-[background-color,color,transform] duration-150 hover:bg-base-100/70 hover:text-slate-100 active:cursor-grabbing active:scale-95 active:text-slate-50"
+                    className="flex h-8 w-8 shrink-0 cursor-grab touch-none items-center justify-center rounded-[0.35rem] text-slate-400 transition-[background-color,color,transform] duration-150 hover:bg-base-100/70 hover:text-slate-100 active:cursor-grabbing active:scale-95 active:text-slate-50"
                 >
                     <Bars3Icon className="size-5" />
+                </div>
+
+                <div className="min-w-0 flex-1 pt-0.5">
+                    <SortableSummaryHeader
+                        summary={summary}
+                        isExpanded={isExpanded}
+                        onToggleExpand={onToggleExpand}
+                        isInteractive={!isActiveDrag}
+                    />
                 </div>
 
                 <button
                     type="button"
                     onClick={handleDelete}
                     aria-label="Delete item"
-                    className="flex h-8 w-8 items-center justify-center rounded-[0.35rem] text-slate-400 transition-[background-color,color,transform] duration-150 hover:bg-red-500/10 hover:text-red-300 active:scale-95"
+                    className="ml-auto flex h-8 w-8 shrink-0 items-center justify-center rounded-[0.35rem] text-slate-400 transition-[background-color,color,transform] duration-150 hover:bg-red-500/10 hover:text-red-300 active:scale-95"
                 >
                     <TrashIcon className="size-5" />
                 </button>
             </div>
-            <div className="min-w-0">
-                <SortableSummaryHeader
-                    summary={summary}
-                    isExpanded={isExpanded}
-                    onToggleExpand={onToggleExpand}
-                    isInteractive={!isActiveDrag}
-                />
 
-                {isExpanded ? (
-                    <div
-                        className={clsx(
-                            "pt-3 transition-opacity duration-150",
-                            !isActiveDrag && "editor-panel-enter",
-                            isActiveDrag && "pointer-events-none select-none opacity-70"
-                        )}
-                    >
-                        {children}
-                    </div>
-                ) : null}
-            </div>
+            {isExpanded && !isActiveDrag ? (
+                <div
+                    className={clsx(
+                        "mt-3 border-t border-slate-500/16 pt-3 transition-opacity duration-150",
+                        "editor-panel-enter",
+                    )}
+                >
+                    {children}
+                </div>
+            ) : null}
 
         </div>
     )

--- a/src/features/sortable/List.tsx
+++ b/src/features/sortable/List.tsx
@@ -1,5 +1,5 @@
 import { DndContext, closestCenter, PointerSensor, useSensor, useSensors } from "@dnd-kit/core"
-import { restrictToVerticalAxis } from "@dnd-kit/modifiers"
+import { restrictToParentElement, restrictToVerticalAxis } from "@dnd-kit/modifiers"
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable"
 import { useSortHook } from "@/features/editor/hooks/useSort"
 import { PlusCircleIcon } from "@heroicons/react/24/outline"
@@ -7,9 +7,9 @@ import { useInterfaceStore } from "@/shared/store/useInterfaceStore"
 import Button from "@/shared/ui/Button"
 import SortableItem from "@/features/sortable/Item"
 import EditorSection from "@/shared/ui/EditorSection"
-import { useState } from "react"
+import { useMemo, useRef, useState } from "react"
 import type { ReactNode } from "react"
-import type { DragEndEvent, DragStartEvent, UniqueIdentifier } from "@dnd-kit/core"
+import type { DragEndEvent, DragStartEvent, Modifier, UniqueIdentifier } from "@dnd-kit/core"
 import type { ItemSectionKey, SectionItemMap } from "@/entities/resume/types"
 
 export type SortableItemSummary = {
@@ -38,11 +38,26 @@ export default function SortableList<K extends ItemSectionKey>({
             distance: 8,
         },
     }))
-    const sortableItems: UniqueIdentifier[] = items.map(item => item.id)
     const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null)
     const [overId, setOverId] = useState<UniqueIdentifier | null>(null)
     const [expandedId, setExpandedId] = useState<UniqueIdentifier | null>(null)
+    const sortableListRef = useRef<HTMLDivElement | null>(null)
+    const sortableItems: UniqueIdentifier[] = items.map(item => item.id)
     const activeIndex = activeId ? sortableItems.indexOf(activeId) : -1
+    const restrictToSortableListTop = useMemo<Modifier>(() => ({ draggingNodeRect, transform }) => {
+        const sortableListRect = sortableListRef.current?.getBoundingClientRect()
+
+        if (!draggingNodeRect || !sortableListRect) {
+            return transform
+        }
+
+        const minY = sortableListRect.top - draggingNodeRect.top
+
+        return {
+            ...transform,
+            y: Math.max(transform.y, minY),
+        }
+    }, [])
     const resolvedExpandedId = expandedId !== null && sortableItems.includes(expandedId)
             ? expandedId
             : sortableItems.length === 1
@@ -75,31 +90,31 @@ export default function SortableList<K extends ItemSectionKey>({
 
     return (
         <EditorSection title={header} testId={`editor-section-${section}`}>
-            <DndContext
-                sensors={sensors}
-                modifiers={[restrictToVerticalAxis]}
-                collisionDetection={closestCenter}
-                onDragStart={handleDragStart}
-                onDragOver={(event) => setOverId(event.over?.id ?? null)}
-                onDragCancel={handleDragCancel}
-                onDragEnd={handleDragEndWithState}
-            >
-                <SortableContext items={sortableItems} strategy={verticalListSortingStrategy}>
-                    <Button
-                        variant="surface"
-                        text="Add an item"
-                        icon={<PlusCircleIcon className="size-5" />}
-                        onClick={handleAddItem}
-                        isStretch={true}
-                        className="h-12 justify-start border-slate-500/34 bg-base-200/28 px-4 hover:border-slate-400/45"
-                    />
+            <Button
+                variant="surface"
+                text="Add an item"
+                icon={<PlusCircleIcon className="size-5" />}
+                onClick={handleAddItem}
+                isStretch={true}
+                className="h-12 justify-start border-slate-500/34 bg-base-200/28 px-4 hover:border-slate-400/45"
+            />
 
-                    {items.length === 0 ? (
-                        <div className="animate-fade-in rounded-[0.35rem] border border-dashed border-slate-500/30 bg-base-200/28 px-4 py-8 text-center text-sm text-slate-500">
-                            Click the add button to make a list.
-                        </div>
-                    ) : (
-                        <div className="space-y-3">
+            {items.length === 0 ? (
+                <div className="animate-fade-in rounded-[0.35rem] border border-dashed border-slate-500/30 bg-base-200/28 px-4 py-8 text-center text-sm text-slate-500">
+                    Add an item to make a list.
+                </div>
+            ) : (
+                <DndContext
+                    sensors={sensors}
+                    modifiers={[restrictToVerticalAxis, restrictToParentElement, restrictToSortableListTop]}
+                    collisionDetection={closestCenter}
+                    onDragStart={handleDragStart}
+                    onDragOver={(event) => setOverId(event.over?.id ?? null)}
+                    onDragCancel={handleDragCancel}
+                    onDragEnd={handleDragEndWithState}
+                >
+                    <SortableContext items={sortableItems} strategy={verticalListSortingStrategy}>
+                        <div ref={sortableListRef} className="space-y-3">
                             {items.map((item, index) => (
                                 <SortableItem
                                     key={item.id}
@@ -122,10 +137,9 @@ export default function SortableList<K extends ItemSectionKey>({
                                 </SortableItem>
                             ))}
                         </div>
-                    )}
-
-                </SortableContext>
-            </DndContext>
+                    </SortableContext>
+                </DndContext>
+            )}
         </EditorSection>
     )
 }

--- a/src/shared/ui/Checkbox.tsx
+++ b/src/shared/ui/Checkbox.tsx
@@ -22,7 +22,7 @@ export default function Checkbox({
                 className={clsx(
                     "label flex min-h-11 justify-start gap-3 text-sm text-slate-200",
                     isFramed
-                        ? "rounded-[var(--radius-field)] border border-slate-500/38 bg-base-200/28 px-3 py-2.5"
+                        ? "rounded-[var(--radius-field)] border border-slate-500/38 bg-slate-900/42 px-3 py-2.5"
                         : "rounded-[0.35rem] px-0 py-2 text-slate-100",
                 )}
             >
@@ -30,7 +30,7 @@ export default function Checkbox({
                     type="checkbox"
                     checked={isChecked ?? false}
                     className={clsx(
-                        "checkbox checkbox-sm mt-0.5 shrink-0 rounded-[0.22rem] bg-slate-950/68 checked:bg-primary checked:text-primary-content",
+                        "checkbox checkbox-sm mt-0.5 shrink-0 rounded-[0.22rem] bg-slate-900/72 checked:bg-primary checked:text-primary-content",
                         isFramed
                             ? "border border-slate-500/62 checked:border-primary"
                             : "border border-slate-500/50 checked:border-primary",

--- a/src/shared/ui/Input.tsx
+++ b/src/shared/ui/Input.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx"
-import { useId } from "react"
+import { useId, useState } from "react"
 import type { ChangeEventHandler, HTMLInputTypeAttribute } from "react"
 
 type InputProps = {
@@ -12,6 +12,10 @@ type InputProps = {
     isStretch?: boolean
     isDisabled?: boolean
     noPadding?: boolean
+    maxLength?: number
+    pattern?: string
+    inputMode?: "none" | "text" | "tel" | "url" | "email" | "numeric" | "decimal" | "search"
+    autoComplete?: string
 }
 
 export default function Input({
@@ -24,8 +28,57 @@ export default function Input({
     isStretch = false,
     isDisabled = false,
     noPadding = false,
+    maxLength,
+    pattern,
+    inputMode,
+    autoComplete,
 }: InputProps) {
     const inputId = useId()
+    const [fileName, setFileName] = useState("")
+
+    if (type === "file") {
+        return (
+            <fieldset className={clsx(
+                "fieldset gap-1.5",
+                noPadding && "p-0",
+            )}>
+                {label ? (
+                    <label htmlFor={inputId} className="fieldset-legend text-xs font-medium uppercase tracking-[0.18em] text-slate-400">
+                        {label}
+                    </label>
+                ) : null}
+                <label
+                    htmlFor={inputId}
+                    className={clsx(
+                        "editor-control editor-file-control flex min-h-11 items-center gap-3 rounded-[var(--radius-field)] text-sm",
+                        isStretch && "w-full",
+                        isDisabled ? "cursor-not-allowed opacity-55" : "cursor-pointer",
+                    )}
+                >
+                    <span className="shrink-0 border-r border-slate-500/30 bg-slate-800/42 px-4 py-3 font-medium text-slate-100">
+                        Browse
+                    </span>
+                    <span className="min-w-0 flex-1 truncate px-1 py-3 text-slate-300">
+                        {fileName || "No file selected"}
+                    </span>
+                    <input
+                        id={inputId}
+                        type="file"
+                        {...(accept === "image" && { accept: "image/*" })}
+                        {...(accept === "json" && { accept: ".json,application/json,text/json" })}
+                        aria-label={label}
+                        disabled={isDisabled}
+                        onChange={(event) => {
+                            setFileName(event.target.files?.[0]?.name ?? "")
+                            onChange?.(event)
+                            if (!event.currentTarget.value) setFileName("")
+                        }}
+                        className="sr-only"
+                    />
+                </label>
+            </fieldset>
+        )
+    }
 
     return (
         <fieldset className={clsx(
@@ -40,19 +93,19 @@ export default function Input({
             <input
                 id={inputId}
                 type={type}
-                {...(type !== "file" && { value: value ?? "" })}
-                {...(type === "file" && accept === "image" && { accept: "image/*" })}
-                {...(type === "file" && accept === "json" && { accept: ".json,application/json,text/json" })}
+                value={value ?? ""}
                 placeholder={placeholder}
                 aria-label={label}
                 disabled={isDisabled}
                 onChange={onChange}
+                maxLength={maxLength}
+                pattern={pattern}
+                inputMode={inputMode}
+                autoComplete={autoComplete}
                 className={clsx(
                     "editor-control min-h-11 text-sm",
                     isStretch && "w-full",
-                    type === "file"
-                        ? "file-input w-full rounded-[var(--radius-field)] px-0 file:mr-4 file:border-0 file:border-r file:border-base-300 file:bg-base-300/70 file:px-4 file:text-sm file:font-medium file:text-slate-200"
-                        : "input rounded-[var(--radius-field)]",
+                    "input rounded-[var(--radius-field)]",
                     type === "number" && "[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:m-0 [&::-webkit-inner-spin-button]:m-0",
                 )}
             />

--- a/src/shared/ui/Select.tsx
+++ b/src/shared/ui/Select.tsx
@@ -55,14 +55,14 @@ export default function Select({
                     multiValue: () => "flex items-center gap-1 rounded-[0.2rem] bg-primary/18 px-2 py-0.5 text-primary-content",
                     multiValueLabel: () => "text-xs text-slate-100",
                     multiValueRemove: () => "cursor-pointer text-slate-100 hover:bg-transparent",
-                    menu: () => "mt-1 w-full rounded-[var(--radius-field)] border border-base-300 bg-base-200 shadow-xl",
+                    menu: () => "mt-1 w-full rounded-[var(--radius-field)] border border-slate-500/38 bg-slate-900/96 shadow-xl backdrop-blur-xl",
                     option: ({ isFocused }) =>
                         clsx(
                             "cursor-pointer px-3 py-1.5 text-sm",
                             isFocused && "bg-primary/18 text-slate-100",
                         ),
-                    noOptionsMessage: () => "rounded-[var(--radius-field)] border border-dashed border-base-300 bg-base-200 px-3 py-2 text-sm text-slate-500",
-                    indicatorsContainer: () => "flex items-center gap-1",
+                    noOptionsMessage: () => "rounded-[var(--radius-field)] border border-dashed border-slate-500/38 bg-slate-900/55 px-3 py-2 text-sm text-slate-500",
+                    indicatorsContainer: () => "flex items-center gap-1 border-l border-slate-500/34 pl-2",
                     clearIndicator: () => "p-1 text-slate-400 hover:text-error",
                     dropdownIndicator: ({ isFocused }) =>
                         clsx(

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -1,0 +1,7 @@
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/src/widgets/layout/Default.tsx
+++ b/src/widgets/layout/Default.tsx
@@ -1,35 +1,30 @@
 import {
-    ArrowDownTrayIcon,
     ArrowRightCircleIcon,
-    ArrowsUpDownIcon,
-    EyeIcon,
+    ChatBubbleLeftRightIcon,
+    PencilSquareIcon,
     RectangleStackIcon,
 } from "@heroicons/react/24/outline"
-import Button from "@/shared/ui/Button"
 import { useDefaultHook } from "@/features/editor/hooks/useDefault"
 
 const proofCards = [
     {
-        title: "Structured editing",
-        description: "Work through focused sections instead of fighting a blank page. Every field stays organized and easy to revisit.",
+        title: "Free resume builder",
+        description: "Create and export your resume in the browser without a signup wall or paid gate.",
+        eyebrow: "Free",
         icon: RectangleStackIcon,
     },
     {
-        title: "Live PDF preview",
-        description: "See the document update as you type so spacing, hierarchy, and readability stay visible while you build.",
-        icon: EyeIcon,
+        title: "Ready to edit and view",
+        description: "Fill focused fields and keep the live resume preview beside you while you refine the output.",
+        eyebrow: "Live editor",
+        icon: PencilSquareIcon,
     },
     {
-        title: "Export and reorder",
-        description: "Drag sections into place, refine the flow, and export a polished resume without leaving the browser.",
-        icon: ArrowDownTrayIcon,
+        title: "Chat assistant guidance",
+        description: "Ask for help adding, editing, or improving one resume section at a time for cleaner wording.",
+        eyebrow: "AI guided",
+        icon: ChatBubbleLeftRightIcon,
     },
-]
-
-const editorHighlights = [
-    "Browser based",
-    "Drag to reorder",
-    "PDF ready",
 ]
 
 export default function Default() {
@@ -38,202 +33,77 @@ export default function Default() {
     return (
         <main data-testid="landing-shell" className="landing-shell overflow-x-hidden px-4 py-4 sm:px-6 sm:py-5 lg:h-dvh lg:px-8 lg:py-6">
             <div className="mx-auto flex min-h-[calc(100dvh-2rem)] w-full max-w-[1380px] flex-col justify-center lg:h-[calc(100dvh-3rem)] lg:min-h-0">
-                <section className="landing-hero-grid flex-1">
-                    <div data-testid="landing-hero-copy" className="landing-rise-in flex max-w-2xl flex-col items-start">
-                        <p className="font-manrope text-xs uppercase tracking-[0.28em] text-slate-400 sm:text-[0.9rem]">
-                            Click. Fill. Done.
-                        </p>
-
+                <section className="landing-hero-grid flex-1 lg:pb-8">
+                    <div data-testid="landing-hero-copy" className="landing-rise-in flex max-w-3xl flex-col items-start">
                         <h1
                             id="landing-title"
-                            className="mt-3 max-w-3xl font-manrope text-3xl font-semibold leading-[1.03] text-slate-50 sm:text-5xl lg:text-[3.95rem]"
+                            className="max-w-4xl font-manrope text-5xl font-semibold leading-[0.98] text-slate-50 sm:text-7xl lg:text-[6.4rem]"
                         >
-                            Free Resume Builder with Live PDF Preview
+                            This is{" "}
+                            <span className="text-slate-300 drop-shadow-[0_0_28px_rgba(203,213,225,0.18)]">
+                                Resume Makinator
+                            </span>
                         </h1>
 
-                        <p className="mt-4 max-w-2xl text-[0.95rem] leading-7 text-slate-300 sm:text-lg lg:max-w-xl lg:text-[1rem] lg:leading-7">
-                            Resume Makinator gives you a cleaner way to shape your resume: structured inputs,
-                            focused editing, live preview, and fast PDF export in one workspace.
+                        <p className="mt-5 max-w-2xl text-base leading-7 text-slate-300 sm:text-lg">
+                            A simple free resume builder with structured editing, a live preview, and a chat assistant that helps you shape better resume content.
                         </p>
 
-                        <div className="mt-4 rounded-[0.55rem] border border-slate-500/24 bg-base-200/36 px-4 py-3 shadow-[0_16px_40px_rgba(2,6,23,0.18)] lg:max-w-[38rem]">
-                            <p className="font-manrope text-base font-semibold text-slate-100 sm:text-xl">
-                                This is Resume Makinator
-                            </p>
-                            <p className="mt-1.5 max-w-xl text-sm leading-6 text-slate-400 sm:text-[0.95rem]">
-                                Minimal by default, practical in use, and built to feel like a modern editing tool instead of a cluttered form wall.
-                            </p>
-                        </div>
-
-                        <div className="mt-5 flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:items-center">
-                            <Button
-                                variant="entry"
-                                text="Get started"
-                                icon={<ArrowRightCircleIcon className="size-7" />}
+                        <div className="mt-7">
+                            <button
+                                type="button"
+                                aria-label="Get started"
                                 onClick={buttonStart}
-                                className="h-[3.25rem] justify-center px-6 text-base sm:min-w-52"
-                            />
-                            <p className="hidden text-sm text-slate-400 sm:block">
-                                Start in the browser. No signup wall, no extra setup.
-                            </p>
-                        </div>
-
-                        <div className="mt-4 hidden flex-wrap gap-2 sm:flex lg:mt-3">
-                            {editorHighlights.map((highlight) => (
-                                <div
-                                    key={highlight}
-                                    className="rounded-full border border-slate-500/24 bg-base-200/28 px-4 py-2 text-sm text-slate-300"
+                                className="group relative inline-flex min-h-16 min-w-[22rem] items-center overflow-hidden rounded-full border border-sky-200/30 bg-sky-300/14 px-5 font-manrope text-base font-semibold text-sky-100 shadow-[0_18px_44px_rgba(14,165,233,0.18)] transition-[border-color,background-color] duration-200 hover:border-sky-100/55 hover:bg-sky-300/22 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-200/60 sm:text-lg"
+                            >
+                                <span
+                                    aria-hidden="true"
+                                    className="absolute left-5 z-10 transition-transform duration-300 ease-out group-hover:translate-x-[17.2rem]"
                                 >
-                                    {highlight}
-                                </div>
-                            ))}
+                                    <ArrowRightCircleIcon className="size-9 sm:size-10" />
+                                </span>
+                                <span className="absolute inset-0 flex items-center justify-center pl-10 transition-all duration-300 ease-out group-hover:-translate-x-8 group-hover:opacity-0">
+                                    <span>Start editing in your browser</span>
+                                </span>
+                                <span className="absolute inset-0 flex translate-x-8 items-center justify-center opacity-0 transition-all duration-300 ease-out group-hover:translate-x-0 group-hover:opacity-100">
+                                    <span>Get started</span>
+                                </span>
+                            </button>
                         </div>
                     </div>
 
                     <div data-testid="landing-hero-visual" className="landing-rise-in-delay flex w-full justify-center lg:justify-end">
-                        <div className="landing-hero-visual w-full max-w-[22rem] sm:max-w-[30rem] lg:max-w-[35rem] xl:max-w-[39rem]">
+                        <div className="landing-hero-visual w-full max-w-[24rem] sm:max-w-[32rem] lg:max-w-[34rem]">
                             <div className="landing-hero-glow" aria-hidden="true" />
 
-                            <div className="landing-mock-shell editor-glass-surface landing-float">
-                                <div className="flex items-center justify-between gap-4 border-b border-slate-500/20 px-4 py-2.5 sm:px-5 sm:py-3">
-                                    <div>
-                                        <p className="font-manrope text-[0.72rem] uppercase tracking-[0.24em] text-slate-400">
-                                            Resume Builder
+                            <div
+                                data-testid="landing-proof-grid"
+                                className="grid gap-3"
+                            >
+                                {proofCards.map(({ title, description, eyebrow, icon: Icon }) => (
+                                    <article
+                                        key={title}
+                                        data-testid="landing-proof-card"
+                                        className="editor-panel-surface rounded-[0.85rem] px-4 py-4 sm:px-5 sm:py-5"
+                                    >
+                                        <div className="flex items-center justify-between gap-3">
+                                            <p className="text-[0.68rem] uppercase tracking-[0.22em] text-slate-500">
+                                                {eyebrow}
+                                            </p>
+                                            <div className="flex h-9 w-9 items-center justify-center rounded-[0.6rem] border border-slate-400/18 bg-slate-900/35 text-slate-100">
+                                                <Icon className="size-4" />
+                                            </div>
+                                        </div>
+                                        <h2 className="mt-4 font-manrope text-base font-semibold leading-6 text-slate-50 sm:text-lg">
+                                            {title}
+                                        </h2>
+                                        <p className="mt-2 text-sm leading-6 text-slate-400">
+                                            {description}
                                         </p>
-                                        <p className="mt-1 text-sm text-slate-300">
-                                            Edit, preview, and export from one workspace
-                                        </p>
-                                    </div>
-                                    <div className="rounded-full border border-sky-400/28 bg-sky-400/10 px-3 py-1 text-[0.72rem] font-medium uppercase tracking-[0.18em] text-sky-200">
-                                        Live
-                                    </div>
-                                </div>
-
-                                <div className="landing-mock-grid">
-                                    <div className="rounded-[0.65rem] border border-slate-500/22 bg-slate-950/24 p-3">
-                                        <div className="flex items-center gap-3 pb-3">
-                                            <div className="flex h-10 w-10 items-center justify-center rounded-[0.5rem] border border-slate-400/18 bg-base-200/52 text-slate-200">
-                                                <RectangleStackIcon className="size-5" />
-                                            </div>
-                                            <div className="min-w-0">
-                                                <p className="truncate font-manrope text-sm font-semibold text-slate-100">
-                                                    About you
-                                                </p>
-                                                <p className="truncate text-xs uppercase tracking-[0.16em] text-slate-500">
-                                                    Structured form
-                                                </p>
-                                            </div>
-                                        </div>
-
-                                        <div className="space-y-3">
-                                            <div className="rounded-[0.5rem] border border-slate-500/18 bg-base-200/36 px-3 py-2.5">
-                                                <p className="text-[0.7rem] uppercase tracking-[0.24em] text-slate-500">
-                                                    Name
-                                                </p>
-                                                <p className="mt-2 text-sm text-slate-200">Mark Kenneth Pelayo</p>
-                                            </div>
-                                            <div className="rounded-[0.5rem] border border-slate-500/18 bg-base-200/36 px-3 py-2.5">
-                                                <p className="text-[0.7rem] uppercase tracking-[0.24em] text-slate-500">
-                                                    Position
-                                                </p>
-                                                <p className="mt-2 text-sm text-slate-200">Web Developer</p>
-                                            </div>
-                                            <div className="rounded-[0.7rem] border border-slate-500/16 bg-base-200/28 px-3 py-3">
-                                                <div className="flex items-start gap-2">
-                                                    <ArrowsUpDownIcon className="mt-0.5 size-4 text-slate-400" />
-                                                    <div>
-                                                        <p className="text-sm text-slate-200">Education</p>
-                                                        <p className="mt-1 text-xs leading-6 text-slate-400">
-                                                            Reorder sections and keep the flow readable.
-                                                        </p>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-
-                                    <div className="rounded-[0.75rem] border border-slate-500/20 bg-slate-950/30 p-3 sm:p-4">
-                                        <div className="flex items-center justify-between">
-                                            <div>
-                                                <p className="font-manrope text-sm font-semibold text-slate-100">
-                                                    Preview
-                                                </p>
-                                                <p className="mt-1 text-xs uppercase tracking-[0.18em] text-slate-500">
-                                                    A4 · Whitepaper
-                                                </p>
-                                            </div>
-                                            <EyeIcon className="size-5 text-slate-400" />
-                                        </div>
-
-                                        <div className="landing-preview-sheet mt-4">
-                                            <div className="space-y-3">
-                                                <div>
-                                                    <div className="h-3.5 w-40 rounded-full bg-slate-900/70" />
-                                                    <div className="mt-2 h-2.5 w-28 rounded-full bg-slate-500/40" />
-                                                </div>
-                                                <div className="space-y-2">
-                                                    <div className="h-2.5 w-full rounded-full bg-slate-400/35" />
-                                                    <div className="h-2.5 w-[92%] rounded-full bg-slate-400/30" />
-                                                    <div className="h-2.5 w-[75%] rounded-full bg-slate-400/24" />
-                                                </div>
-                                                <div className="grid gap-3 pt-3 sm:grid-cols-2">
-                                                    <div className="space-y-2">
-                                                        <div className="h-2.5 w-24 rounded-full bg-sky-500/30" />
-                                                        <div className="h-2.5 w-full rounded-full bg-slate-400/24" />
-                                                        <div className="h-2.5 w-[88%] rounded-full bg-slate-400/18" />
-                                                    </div>
-                                                    <div className="space-y-2">
-                                                        <div className="h-2.5 w-24 rounded-full bg-sky-500/22" />
-                                                        <div className="h-2.5 w-full rounded-full bg-slate-400/24" />
-                                                        <div className="h-2.5 w-[82%] rounded-full bg-slate-400/18" />
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-
-                                        <div className="mt-4 grid gap-3 sm:grid-cols-2">
-                                            <div className="rounded-[0.55rem] border border-slate-500/18 bg-base-200/28 px-3 py-2">
-                                                <p className="text-[0.68rem] uppercase tracking-[0.22em] text-slate-500">
-                                                    Live update
-                                                </p>
-                                                <p className="mt-2 text-sm text-slate-200">See changes instantly</p>
-                                            </div>
-                                            <div className="rounded-[0.55rem] border border-slate-500/18 bg-base-200/28 px-3 py-2">
-                                                <p className="text-[0.68rem] uppercase tracking-[0.22em] text-slate-500">
-                                                    Export
-                                                </p>
-                                                <p className="mt-2 text-sm text-slate-200">Fast PDF output</p>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
+                                    </article>
+                                ))}
                             </div>
                         </div>
-                    </div>
-                </section>
-
-                <section className="landing-rise-in-delay-2 lg:pt-2">
-                    <div
-                        data-testid="landing-proof-grid"
-                        className="grid grid-cols-3 gap-2.5 sm:gap-4"
-                    >
-                        {proofCards.map(({ title, description, icon: Icon }) => (
-                            <article
-                                key={title}
-                                data-testid="landing-proof-card"
-                                className="editor-panel-surface rounded-[0.75rem] px-3 py-3 sm:rounded-[0.85rem] sm:px-5 sm:py-5"
-                            >
-                                <div className="flex h-9 w-9 items-center justify-center rounded-[0.6rem] border border-slate-400/18 bg-slate-900/35 text-slate-100 sm:h-12 sm:w-12 sm:rounded-[0.75rem]">
-                                    <Icon className="size-4 sm:size-6" />
-                                </div>
-                                <h2 className="mt-3 font-manrope text-[0.78rem] font-semibold leading-5 text-slate-50 sm:mt-5 sm:text-xl lg:mt-3 lg:text-[1.02rem] lg:leading-6">
-                                    {title}
-                                </h2>
-                                <p className="mt-3 hidden text-sm leading-7 text-slate-400 xl:block xl:text-[0.95rem]">
-                                    {description}
-                                </p>
-                            </article>
-                        ))}
                     </div>
                 </section>
             </div>

--- a/src/widgets/layout/Navigation.tsx
+++ b/src/widgets/layout/Navigation.tsx
@@ -156,7 +156,7 @@ export default function Navigation({ active }: NavigationProps) {
                         ))}
                     </div>
 
-                    <div className="h-px bg-linear-to-r from-base-300 via-slate-500/50 to-transparent" />
+                    <div className="h-px bg-slate-500/55" />
 
                     <div className="space-y-2">
                         {secondaryTabs.map((item) => (
@@ -188,7 +188,7 @@ export default function Navigation({ active }: NavigationProps) {
                         ))}
                     </div>
 
-                    <div className="h-px w-full bg-linear-to-r from-transparent via-slate-500/55 to-transparent" />
+                    <div className="h-px w-full bg-slate-500/55" />
 
                     <div data-testid="editor-sidebar-secondary-group" className="flex w-full flex-col items-center gap-2">
                         {secondaryTabs.map((item) => (

--- a/src/widgets/modals/Privacy.tsx
+++ b/src/widgets/modals/Privacy.tsx
@@ -32,7 +32,11 @@ export default function PrivacyModal() {
                     <h3 className="text-lg font-manrope font-bold">Privacy & Security Notice</h3>
                     <div className="space-y-3 py-4">
                         <p className="text-sm leading-relaxed">
-                            I do not <span className="font-medium text-primary">send or store</span> any of your information on my server. All data is kept locally in your browser’s storage, so your information stays on your device and under your control. This design greatly reduces the risk of data exposure from my side, because there is no central database for anyone to hack or leak.
+                            I do not <span className="font-medium text-primary">store</span> your resume information on my server. Your resume data is kept locally in your browser’s storage, so your information stays on your device and under your control. This design greatly reduces the risk of data exposure from my side, because there is no central database for anyone to hack or leak.
+                        </p>
+
+                        <p className="text-sm leading-relaxed">
+                            If you use the <span className="font-medium text-primary">Chat Assistant</span>, only the needed resume context is sent to the AI service so it can generate a better response. This app does not store that AI request data on my server.
                         </p>
 
                         <p className="text-sm leading-relaxed">

--- a/src/widgets/modals/Reset.tsx
+++ b/src/widgets/modals/Reset.tsx
@@ -34,7 +34,7 @@ export default function ResetModal() {
                         <div className="space-y-2">
                             <h3 className="font-manrope text-xl font-semibold text-slate-50">Reset everything?</h3>
                             <p className="text-sm leading-6 text-slate-300">
-                                This will remove all saved resume data from this browser and return the editor to its default state.
+                                This will clear all saved resume information from this browser and reset the editor to its original state.
                             </p>
                         </div>
                     </div>
@@ -46,7 +46,7 @@ export default function ResetModal() {
             actions={(
                 <>
                         <Button variant="surface" text="Cancel" onClick={() => handleCancel()} />
-                        <Button variant="danger" text="Reset everything" onClick={() => handleConfirm()}/>
+                        <Button variant="danger" text="Reset" onClick={() => handleConfirm()}/>
                 </>
             )}
             allowOutsideClick={true}

--- a/test/e2e/app.spec.ts
+++ b/test/e2e/app.spec.ts
@@ -21,9 +21,9 @@ test.describe("resume editor", () => {
     await expect(page.getByTestId("landing-hero-copy")).toBeVisible()
     await expect(page.getByTestId("landing-hero-visual")).toBeVisible()
     await expect(page.getByTestId("landing-proof-grid")).toBeVisible()
-    await expect(page.getByTestId("landing-proof-grid").getByText("Structured editing")).toBeVisible()
-    await expect(page.getByTestId("landing-proof-grid").getByText("Live PDF preview")).toBeVisible()
-    await expect(page.getByTestId("landing-proof-grid").getByText("Export and reorder")).toBeVisible()
+    await expect(page.getByTestId("landing-proof-grid").getByText("Free resume builder")).toBeVisible()
+    await expect(page.getByTestId("landing-proof-grid").getByText("Ready to edit and view")).toBeVisible()
+    await expect(page.getByTestId("landing-proof-grid").getByText("Chat assistant guidance")).toBeVisible()
 
     const copyBox = await page.getByTestId("landing-hero-copy").boundingBox()
     const visualBox = await page.getByTestId("landing-hero-visual").boundingBox()
@@ -227,7 +227,7 @@ test.describe("resume editor", () => {
     await expect(page.getByTestId("sortable-item")).toHaveCount(1)
   })
 
-  test("dragging repeated entries shows active and drop-target feedback before reorder", async ({ page }) => {
+  test("dragging repeated entries uses modify-components-style displacement before drop", async ({ page }) => {
     await page.setViewportSize({ width: 1440, height: 900 })
     await page.goto("/")
     await page.getByRole("button", { name: "Get started" }).click()
@@ -235,15 +235,19 @@ test.describe("resume editor", () => {
 
     await page.getByRole("button", { name: "Work Experience" }).click()
     await page.getByRole("button", { name: "Add an item" }).click()
+    await page.getByRole("textbox", { name: "Position" }).fill("Backend Engineer")
     await page.getByRole("button", { name: "Add an item" }).click()
+    await page.getByRole("textbox", { name: "Position" }).last().fill("Frontend Engineer")
 
     const dragHandle = page.getByTestId("sortable-handle").first()
-    const activeCard = page.getByTestId("sortable-item").first()
     const targetCard = page.getByTestId("sortable-item").nth(1)
+    const backendCard = page.getByTestId("sortable-item").filter({ hasText: "Backend Engineer" })
+    const frontendCard = page.getByTestId("sortable-item").filter({ hasText: "Frontend Engineer" })
     const handleBox = await dragHandle.boundingBox()
+    const firstBox = await backendCard.boundingBox()
     const targetBox = await targetCard.boundingBox()
 
-    if (!handleBox || !targetBox) {
+    if (!handleBox || !firstBox || !targetBox) {
       throw new Error("Sortable handles did not render for drag feedback test.")
     }
 
@@ -251,8 +255,143 @@ test.describe("resume editor", () => {
     await page.mouse.down()
     await page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + targetBox.height * 0.78, { steps: 10 })
 
-    await expect(activeCard).toHaveAttribute("data-state", "dragging")
-    await expect(targetCard).toHaveAttribute("data-drop-position", /before|after/)
+    await expect(backendCard).toHaveAttribute("data-state", "dragging")
+    await expect(frontendCard).toHaveAttribute("data-drop-position", "after")
+
+    const displacedFrontendBox = await frontendCard.boundingBox()
+    if (!displacedFrontendBox) {
+      throw new Error("Sortable target did not remain visible while displaced.")
+    }
+
+    expect(displacedFrontendBox.y).toBeLessThan(targetBox.y - 8)
+
+    await page.mouse.up()
+    await expect(page.getByTestId("sortable-item").first()).toContainText("Frontend Engineer")
+    await expect(page.getByTestId("sortable-item").nth(1)).toContainText("Backend Engineer")
+  })
+
+  test("repeated-entry sorting uses a single vertical row layout like modify components", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await page.goto("/")
+    await page.getByRole("button", { name: "Get started" }).click()
+    await page.getByRole("button", { name: "I understand" }).click()
+
+    await page.getByRole("button", { name: "Work Experience" }).click()
+    await page.getByRole("button", { name: "Add an item" }).click()
+    await page.getByRole("textbox", { name: "Position" }).fill("Backend Engineer")
+    await page.getByRole("button", { name: "Add an item" }).click()
+
+    const firstItem = page.getByTestId("sortable-item").first()
+    const dragHandle = page.getByTestId("sortable-handle").first()
+    const summaryToggle = firstItem.locator("button[aria-expanded]").first()
+    const deleteButton = page.getByLabel("Delete item").first()
+
+    const handleBox = await dragHandle.boundingBox()
+    const summaryBox = await summaryToggle.boundingBox()
+    const deleteBox = await deleteButton.boundingBox()
+    const firstItemBox = await firstItem.boundingBox()
+
+    if (!handleBox || !summaryBox || !deleteBox || !firstItemBox) {
+      throw new Error("Sortable row controls did not render for layout verification.")
+    }
+
+    const handleCenterY = handleBox.y + handleBox.height / 2
+    const summaryCenterY = summaryBox.y + summaryBox.height / 2
+    const deleteCenterY = deleteBox.y + deleteBox.height / 2
+
+    expect(Math.abs(handleCenterY - summaryCenterY)).toBeLessThan(8)
+    expect(Math.abs(deleteCenterY - summaryCenterY)).toBeLessThan(8)
+    expect(handleBox.x).toBeLessThan(summaryBox.x)
+    expect(summaryBox.x + summaryBox.width).toBeLessThan(deleteBox.x)
+
+    await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(handleBox.x + handleBox.width / 2 + 80, handleBox.y + handleBox.height + 64, { steps: 10 })
+
+    const draggingItemBox = await firstItem.boundingBox()
+    if (!draggingItemBox) {
+      throw new Error("Sortable item disappeared while verifying vertical-only drag.")
+    }
+
+    expect(Math.abs(draggingItemBox.x - firstItemBox.x)).toBeLessThan(2)
+
+    await page.mouse.up()
+  })
+
+  test("dragging an entry into the first slot stays below the add button", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await page.goto("/")
+    await page.getByRole("button", { name: "Get started" }).click()
+    await page.getByRole("button", { name: "I understand" }).click()
+
+    await page.getByRole("button", { name: "Education" }).click()
+    await page.getByRole("button", { name: "Add an item" }).click()
+    await page.getByRole("button", { name: "Add an item" }).click()
+    await page.getByRole("button", { name: "Add an item" }).click()
+
+    const addButton = page.getByRole("button", { name: "Add an item" })
+    const firstItem = page.getByTestId("sortable-item").first()
+    const activeItem = page.getByTestId("sortable-item").nth(2)
+    const activeHandle = page.getByTestId("sortable-handle").nth(2)
+    const addButtonBox = await addButton.boundingBox()
+    const activeHandleBox = await activeHandle.boundingBox()
+    const firstItemBox = await firstItem.boundingBox()
+
+    if (!addButtonBox || !activeHandleBox || !firstItemBox) {
+      throw new Error("Education sortable controls did not render for first-slot drag test.")
+    }
+
+    await page.mouse.move(activeHandleBox.x + activeHandleBox.width / 2, activeHandleBox.y + activeHandleBox.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(firstItemBox.x + firstItemBox.width / 2, addButtonBox.y - 64, { steps: 12 })
+
+    await expect(activeItem).toHaveAttribute("data-state", "dragging")
+    const draggingBox = await activeItem.boundingBox()
+    if (!draggingBox) {
+      throw new Error("Active sortable item disappeared while dragging into the first slot.")
+    }
+
+    expect(draggingBox.y).toBeGreaterThanOrEqual(addButtonBox.y + addButtonBox.height - 2)
+    expect(draggingBox.y).toBeGreaterThanOrEqual(firstItemBox.y - 2)
+
+    await page.mouse.up()
+  })
+
+  test("dragging the second entry into the first slot stays below the add button", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await page.goto("/")
+    await page.getByRole("button", { name: "Get started" }).click()
+    await page.getByRole("button", { name: "I understand" }).click()
+
+    await page.getByRole("button", { name: "Education" }).click()
+    await page.getByRole("button", { name: "Add an item" }).click()
+    await page.getByRole("button", { name: "Add an item" }).click()
+    await page.getByRole("button", { name: "Add an item" }).click()
+
+    const addButton = page.getByRole("button", { name: "Add an item" })
+    const firstItem = page.getByTestId("sortable-item").first()
+    const activeItem = page.getByTestId("sortable-item").nth(1)
+    const activeHandle = page.getByTestId("sortable-handle").nth(1)
+    const addButtonBox = await addButton.boundingBox()
+    const activeHandleBox = await activeHandle.boundingBox()
+    const firstItemBox = await firstItem.boundingBox()
+
+    if (!addButtonBox || !activeHandleBox || !firstItemBox) {
+      throw new Error("Education sortable controls did not render for second-to-first drag test.")
+    }
+
+    await page.mouse.move(activeHandleBox.x + activeHandleBox.width / 2, activeHandleBox.y + activeHandleBox.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(firstItemBox.x + firstItemBox.width / 2, addButtonBox.y - 64, { steps: 12 })
+
+    await expect(activeItem).toHaveAttribute("data-state", "dragging")
+    const draggingBox = await activeItem.boundingBox()
+    if (!draggingBox) {
+      throw new Error("Second sortable item disappeared while dragging into the first slot.")
+    }
+
+    expect(draggingBox.y).toBeGreaterThanOrEqual(addButtonBox.y + addButtonBox.height - 2)
+    expect(draggingBox.y).toBeGreaterThanOrEqual(firstItemBox.y - 2)
 
     await page.mouse.up()
   })
@@ -292,8 +431,9 @@ test.describe("resume editor", () => {
     await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2)
     await page.mouse.down()
     await page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + targetBox.height * 0.78, { steps: 10 })
-    await expect(targetCard).toHaveAttribute("data-drop-position", /before|after/)
     await page.mouse.up()
+    await expect(page.getByTestId("sortable-item").first()).toContainText("Frontend Engineer")
+    await expect(page.getByTestId("sortable-item").nth(1)).toContainText("Backend Engineer")
   })
 
   test("dragging the last repeated entry keeps the real item visible without a separate overlay ghost", async ({ page }) => {
@@ -330,7 +470,7 @@ test.describe("resume editor", () => {
     await page.mouse.up()
   })
 
-  test("expanded repeated entries keep their content visible while dragging", async ({ page }) => {
+  test("expanded repeated entries hide their inputs while dragging and restore after drop", async ({ page }) => {
     await page.setViewportSize({ width: 1440, height: 900 })
     await page.goto("/")
     await page.getByRole("button", { name: "Get started" }).click()
@@ -338,34 +478,45 @@ test.describe("resume editor", () => {
 
     await page.getByRole("button", { name: "Work Experience" }).click()
     await page.getByRole("button", { name: "Add an item" }).click()
-    await page.getByRole("button", { name: "Add an item" }).click()
-
-    const firstItem = page.getByTestId("sortable-item").first()
     await page.getByRole("textbox", { name: "Position" }).first().fill("Lead Engineer")
     await page.getByRole("textbox", { name: "Company" }).first().fill("OpenAI")
-    await firstItem.locator("button[aria-expanded]").click()
+    await page.getByRole("button", { name: "Add an item" }).click()
+    await page.getByRole("textbox", { name: "Position" }).last().fill("Support Engineer")
+
+    const leadItem = page.getByTestId("sortable-item").filter({ hasText: "Lead Engineer" })
+    await leadItem.locator("button[aria-expanded]").click()
 
     const companyField = page.getByRole("textbox", { name: "Company" }).first()
-    const dragHandle = page.getByTestId("sortable-handle").first()
-    const targetCard = page.getByTestId("sortable-item").nth(1)
+    const dragHandle = leadItem.getByTestId("sortable-handle")
+    const targetCard = page.getByTestId("sortable-item").filter({ hasText: "Support Engineer" })
     const handleBox = await dragHandle.boundingBox()
+    const leadBox = await leadItem.boundingBox()
     const targetBox = await targetCard.boundingBox()
 
-    if (!handleBox || !targetBox) {
+    if (!handleBox || !leadBox || !targetBox) {
       throw new Error("Expanded sortable item did not render for drag-stability test.")
     }
 
-    await expect(firstItem).toHaveAttribute("data-expanded", "true")
+    await expect(leadItem).toHaveAttribute("data-expanded", "true")
     await expect(companyField).toBeVisible()
 
     await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2)
     await page.mouse.down()
     await page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + targetBox.height * 0.78, { steps: 10 })
 
-    await expect(firstItem).toHaveAttribute("data-state", "dragging")
-    await expect(companyField).toBeVisible()
+    await expect(leadItem).toHaveAttribute("data-state", "dragging")
+    await expect(leadItem).toHaveAttribute("data-expanded", "true")
+    await expect(companyField).toBeHidden()
+    const draggingBox = await leadItem.boundingBox()
+    if (!draggingBox) {
+      throw new Error("Expanded sortable item disappeared while dragging.")
+    }
+    expect(draggingBox.y).toBeGreaterThan(leadBox.y - 8)
+    expect(draggingBox.height).toBeLessThan(leadBox.height * 0.6)
 
     await page.mouse.up()
+    await expect(page.getByTestId("sortable-item").filter({ hasText: "Lead Engineer" })).toHaveAttribute("data-expanded", "true")
+    await expect(companyField).toBeVisible()
   })
 
   test("language multiselect selects an option on the first click", async ({ page }) => {
@@ -446,8 +597,8 @@ test.describe("resume editor", () => {
     const exportedPath = testInfo.outputPath("resume-modern-roundtrip.json")
     await download.saveAs(exportedPath)
 
-    await page.getByRole("button", { name: "Reset everything" }).click()
-    await page.getByRole("button", { name: "Reset everything" }).nth(1).click()
+    await page.getByRole("button", { name: "Reset" }).click()
+    await page.getByRole("button", { name: "Reset" }).nth(1).click()
 
     await page.getByRole("button", { name: "Configuration" }).click()
     await expect(page.getByRole("group").filter({
@@ -472,14 +623,14 @@ test.describe("resume editor", () => {
     await page.getByRole("button", { name: "I understand" }).click()
 
     await page.getByRole("button", { name: "Data" }).click()
-    await page.getByRole("button", { name: "Reset everything" }).click()
+    await page.getByRole("button", { name: "Reset" }).click()
 
     const dialog = page.getByRole("dialog")
     await expect(dialog).toBeVisible()
     await page.getByRole("button", { name: "Cancel" }).click()
     await expect(dialog).toBeHidden()
 
-    await page.getByRole("button", { name: "Reset everything" }).click()
+    await page.getByRole("button", { name: "Reset" }).click()
     await expect(dialog).toBeVisible()
     await page.mouse.click(10, 10)
     await expect(dialog).toBeHidden()

--- a/test/e2e/chat-assistant.spec.ts
+++ b/test/e2e/chat-assistant.spec.ts
@@ -1,0 +1,4057 @@
+import { expect, test, type Page, type Route } from "@playwright/test"
+
+const startEditor = async (page: Page) => {
+  await page.goto("/")
+
+  const getStarted = page.getByRole("button", { name: "Get started" })
+  if (await getStarted.count()) {
+    await getStarted.click({ force: true })
+  }
+
+  const privacyAcknowledge = page.getByRole("button", { name: "I understand" })
+  if (await privacyAcknowledge.waitFor({ state: "visible", timeout: 1500 }).then(() => true).catch(() => false)) {
+    await privacyAcknowledge.click()
+  }
+}
+
+const openChatAssistant = async (page: Page) => {
+  await expect(page.getByTestId("chat-assistant-trigger")).toBeVisible()
+  await page.getByTestId("chat-assistant-trigger").click()
+  await expect(page.getByTestId("chat-assistant-panel")).toBeVisible()
+}
+
+const fulfillJson = async (route: Route, status: number, body: unknown) => {
+  await route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  })
+}
+
+const expectNoAutoImproveRequestFields = (payload: Record<string, unknown>) => {
+  expect(payload.autoImprove).toBeUndefined()
+  expect(payload.qualityMode).toBeUndefined()
+  expect(payload.wordingMode).toBeUndefined()
+  expect(payload.exactWording).toBeUndefined()
+  expect(payload.preserveExactWording).toBeUndefined()
+}
+
+const expectNoActiveBoundaryState = (payload: Record<string, unknown>) => {
+  expect(payload.activeDraft).toBeUndefined()
+  expect(payload.pendingAction).toBeUndefined()
+  expect(payload.userDecision).toBeUndefined()
+}
+
+test.describe("chat assistant", () => {
+  test("opens from the desktop edge trigger and shows the empty state", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await startEditor(page)
+
+    await expect(page.getByTestId("chat-assistant-panel")).toHaveCount(0)
+    await expect(page.getByTestId("chat-assistant-trigger")).toBeVisible()
+
+    await openChatAssistant(page)
+    const panel = page.getByTestId("chat-assistant-panel")
+    await expect(panel.getByText("Chat Assistant", { exact: true })).toBeVisible()
+    await expect(page.getByText("Powered with Pollinations.ai")).toBeVisible()
+    await expect(page.getByText("Resume help, right beside your draft")).toHaveCount(0)
+    await expect(page.getByText("Start chatting to improve your resume.")).toHaveCount(0)
+    await expect(page.getByText("Start chatting to improve your resume", { exact: true })).toHaveCount(0)
+    await expect(page.getByRole("textbox", { name: "Message" })).toBeVisible()
+    await expect(panel.locator("label").filter({ hasText: /^Message$/ })).toHaveCount(0)
+    await expect(page.getByRole("button", { name: "Send message" })).toContainText("Send")
+    await expect(page.getByRole("button", { name: "Clear conversation" })).toContainText("Clear conversation")
+  })
+
+  test("opens the chat assistant information dialog with beta and provider guidance", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await startEditor(page)
+    await openChatAssistant(page)
+
+    await page.getByRole("button", { name: "About your Assistant" }).click()
+
+    const dialog = page.getByRole("dialog")
+    await expect(dialog.getByRole("heading", { name: "About your Assistant" })).toBeVisible()
+    await expect(dialog).toContainText("early stage")
+    await expect(dialog).toContainText("responses may be slow")
+    await expect(dialog).toContainText("Clear intent matters")
+    await expect(dialog.getByRole("link", { name: "send a report" })).toHaveAttribute(
+      "href",
+      "https://github.com/mkgp-dev/resume-makinator/issues/new?template=bug_report.md",
+    )
+    await expect(dialog).toContainText("Pollinations AI")
+    await expect(dialog).toContainText("add your own Pollinations key")
+    await expect(dialog).toContainText("shared server allowance is depleted")
+    await expect(dialog).toContainText("one section at a time")
+    await expect(dialog).toContainText("This limit will be improved further in the future")
+  })
+
+  test("uses a full-screen sheet on mobile", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await startEditor(page)
+
+    await openChatAssistant(page)
+
+    const panel = page.getByTestId("chat-assistant-panel")
+    const panelBox = await panel.boundingBox()
+
+    if (!panelBox) {
+      throw new Error("Chat assistant panel did not render on mobile.")
+    }
+
+    expect(panelBox.width).toBeGreaterThanOrEqual(360)
+    expect(panelBox.height).toBeGreaterThanOrEqual(760)
+  })
+
+  test("sends a configured Pollinations key as a bearer token", async ({ page }) => {
+    const apiKey = "sk_12345678901234567890123456789012"
+
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await page.route("**/v1/ai/chat", async (route) => {
+      expect(route.request().headers().authorization).toBe(`Bearer ${apiKey}`)
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "exact_edit",
+        reply: "Draft ready for your summary.",
+        status: "clarification_needed",
+        clarificationQuestion: "What would you like to change?",
+        needsClarification: true,
+        needsConfirmation: false,
+        readyToApply: false,
+        target: { section: "personalDetails", itemId: null, field: "summary", scope: "section" },
+        draft: null,
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await page.getByRole("button", { name: "Configuration" }).click()
+    await page.getByRole("textbox", { name: "Pollinations API key" }).fill(apiKey)
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill("Improve my summary.")
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    await expect(page.getByText("What would you like to change?")).toBeVisible()
+  })
+
+  test("sends a message, disables input while waiting, and persists the conversation after reload", async ({ page }) => {
+    let requestCount = 0
+
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON()
+
+      expect(payload.message).toBe("Make my summary sharper.")
+      expect(payload.activeDraft).toBeUndefined()
+      expect(payload.conversation).toBeUndefined()
+      expect(payload.conversationContext).toBeUndefined()
+      expect(payload.debugProvider).toBeUndefined()
+      expect(payload.resumeData.configuration).toBeUndefined()
+      expect(payload.resumeData.template).toBeUndefined()
+      expect(payload.resumeData.enableInRender).toBeUndefined()
+      expect(payload.resumeData.activePage).toBeUndefined()
+      expect(payload.resumeData.personalDetails.profilePicture).toBeUndefined()
+
+      await new Promise((resolve) => setTimeout(resolve, 250))
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "exact_edit",
+        reply: "Here is a sharper draft for your summary.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: false,
+        readyToApply: false,
+        target: {
+          section: "personalDetails",
+          itemId: null,
+          field: "summary",
+          scope: "resume_wide",
+        },
+        draft: {
+          summary: "Refined your professional summary.",
+          proposedChanges: [
+            {
+              section: "personalDetails",
+              itemId: null,
+              field: "summary",
+              instruction: "Use a sharper summary.",
+              proposedText: "Frontend-focused developer building clean resume workflows.",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await openChatAssistant(page)
+
+    const input = page.getByRole("textbox", { name: "Message" })
+    const send = page.getByRole("button", { name: "Send message" })
+
+    await input.fill("Make my summary sharper.")
+    await send.click()
+
+    await expect(input).toBeDisabled()
+    await expect(send).toBeDisabled()
+    await expect(page.getByText("Hang tight while we prepare a response")).toBeVisible()
+    const userBubble = page.getByTestId("chat-message-bubble").filter({ hasText: "Make my summary sharper." })
+    await expect(userBubble).toBeVisible()
+    await expect(userBubble).toHaveClass(/chat-assistant-bubble--user/)
+    await expect(page.getByTestId("chat-message-bubble").filter({ hasText: "Here is a sharper draft for your summary." })).toBeVisible()
+
+    expect(requestCount).toBe(1)
+
+    await page.reload()
+    await openChatAssistant(page)
+    await expect(page.locator(".chat-bubble").filter({ hasText: "Make my summary sharper." })).toBeVisible()
+    await expect(page.locator(".chat-bubble").filter({ hasText: "Here is a sharper draft for your summary." })).toBeVisible()
+  })
+
+  test("renders inline backend errors and rate limits inside the conversation flow", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      await fulfillJson(route, 429, {
+        error: {
+          code: "rate_limited",
+          message: "Too Many Requests",
+          requestId: "req-rate-limit",
+        },
+      })
+    })
+
+    await startEditor(page)
+    await openChatAssistant(page)
+
+    await page.getByRole("textbox", { name: "Message" }).fill("Help me fix my work summary.")
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    const inlineError = page.getByTestId("chat-inline-error")
+    await expect(inlineError).toBeVisible()
+    await expect(inlineError).toContainText("Too Many Requests")
+    await expect(page.locator(".chat", { hasText: "Too Many Requests" })).toHaveCount(0)
+  })
+
+  test("sends only the last six visible messages as conversation memory", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    let requestCount = 0
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON()
+      expect(payload.activeDraft).toBeUndefined()
+      expect(payload.conversationContext).toBeUndefined()
+      expect(payload.debugProvider).toBeUndefined()
+
+      if (requestCount === 1) {
+        expect(payload.message).toBe("Turn 1")
+        expect(payload.activeDraft).toBeUndefined()
+        expect(payload.conversation).toBeUndefined()
+      }
+
+      if (requestCount === 3) {
+        expect(payload.message).toBe("Turn 3")
+        expect(payload.activeDraft).toBeUndefined()
+        expect(payload.conversation).toEqual([
+          { role: "user", text: "Turn 1" },
+          { role: "assistant", text: "Reply 1" },
+          { role: "user", text: "Turn 2" },
+          { role: "assistant", text: "Reply 2" },
+        ])
+        expect(JSON.stringify(payload.conversation)).not.toContain("Backend warning that should not travel")
+      }
+
+      if (requestCount === 5) {
+        expect(payload.message).toBe("Turn 5")
+        expect(payload.activeDraft).toBeUndefined()
+        expect(payload.conversation).toEqual([
+          { role: "user", text: "Turn 2" },
+          { role: "assistant", text: "Reply 2" },
+          { role: "user", text: "Turn 3" },
+          { role: "assistant", text: "Reply 3" },
+          { role: "user", text: "Turn 4" },
+          { role: "assistant", text: "Reply 4" },
+        ])
+      }
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "grounded_suggestion",
+        reply: `Reply ${requestCount}`,
+        status: "blocked",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: false,
+        readyToApply: false,
+        target: {
+          section: null,
+          itemId: null,
+          field: null,
+          scope: "unknown",
+        },
+        draft: null,
+        warnings: requestCount === 2 ? ["Backend warning that should not travel"] : [],
+      })
+    })
+
+    await startEditor(page)
+    await openChatAssistant(page)
+
+    for (let turn = 1; turn <= 5; turn += 1) {
+      await page.getByRole("textbox", { name: "Message" }).fill(`Turn ${turn}`)
+      await page.getByRole("button", { name: "Send message" }).click()
+      await expect(page.locator(".chat-bubble").filter({ hasText: `Reply ${turn}` })).toBeVisible()
+    }
+
+    expect(requestCount).toBe(5)
+  })
+
+  test("sends pendingAction and confirm decision for conversational delete confirmations", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    let requestCount = 0
+    let projectIds: string[] = []
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON()
+
+      expect(payload.debugProvider).toBeUndefined()
+      expect(payload.conversationContext).toBeUndefined()
+
+      if (requestCount === 1) {
+        expect(payload.message).toBe("Delete all personal projects.")
+        expect(payload.pendingAction).toBeUndefined()
+        expect(payload.userDecision).toBeUndefined()
+        expect(payload.conversation).toBeUndefined()
+        projectIds = payload.resumeData.personalProjects.map((item: { id: string }) => item.id)
+        expect(projectIds).toHaveLength(2)
+
+        await fulfillJson(route, 200, {
+          provider: "pollination",
+          mode: "exact_edit",
+          reply: "Do you want to permanently delete both Forecast Me and Alta from Personal projects?",
+          status: "clarification_needed",
+          clarificationQuestion: "Do you want to permanently delete both Forecast Me and Alta from Personal projects?",
+          needsClarification: true,
+          needsConfirmation: false,
+          readyToApply: false,
+          target: {
+            section: "personalProjects",
+            itemId: null,
+            field: null,
+            scope: "section",
+          },
+          draft: null,
+          warnings: [],
+        })
+        return
+      }
+
+      expect(payload.message).toBe("yes")
+      expect(payload.pendingAction).toEqual({
+        type: "delete",
+        targetSection: "personalProjects",
+        targetItemIds: projectIds,
+      })
+      expect(payload.userDecision).toBe("confirm")
+      expect(payload.conversation).toEqual([
+        { role: "user", text: "Delete all personal projects." },
+        { role: "assistant", text: "Do you want to permanently delete both Forecast Me and Alta from Personal projects?" },
+      ])
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "exact_edit",
+        reply: "Draft ready to delete all Personal projects.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "personalProjects",
+          itemId: null,
+          field: null,
+          scope: "section",
+        },
+        draft: {
+          summary: "Delete all Personal projects.",
+          proposedChanges: [
+            {
+              section: "personalProjects",
+              itemId: null,
+              field: null,
+              instruction: "Remove all personal project entries.",
+              proposedText: "[]",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await page.getByRole("button", { name: "Personal Project" }).click()
+    await page.getByRole("button", { name: "Add an item" }).click()
+    await page.getByLabel("Project name").fill("Forecast Me")
+    await page.getByLabel("Project subtitle").fill("Weather Web Application")
+    await page.getByRole("button", { name: "Add an item" }).click()
+    await page.getByLabel("Project name").last().fill("Alta")
+    await page.getByLabel("Project subtitle").last().fill("Content Management System")
+
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill("Delete all personal projects.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await expect(page.getByTestId("chat-message-bubble").filter({
+      hasText: "Do you want to permanently delete both Forecast Me and Alta from Personal projects?",
+    })).toBeVisible()
+
+    await page.getByRole("textbox", { name: "Message" }).fill("yes")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await expect(page.getByText("Draft ready to delete all Personal projects.")).toBeVisible()
+    expect(requestCount).toBe(2)
+  })
+
+  test("sends reject decision for conversational confirmations and clears pendingAction afterwards", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    let requestCount = 0
+    let projectId = ""
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON()
+      expect(payload.conversationContext).toBeUndefined()
+
+      if (requestCount === 1) {
+        expect(payload.message).toBe("Delete Forecast Me.")
+        expect(payload.pendingAction).toBeUndefined()
+        expect(payload.userDecision).toBeUndefined()
+        projectId = payload.resumeData.personalProjects[0].id
+
+        await fulfillJson(route, 200, {
+          provider: "pollination",
+          mode: "exact_edit",
+          reply: "Do you want to permanently delete Forecast Me from Personal projects?",
+          status: "clarification_needed",
+          clarificationQuestion: "Do you want to permanently delete Forecast Me from Personal projects?",
+          needsClarification: true,
+          needsConfirmation: false,
+          readyToApply: false,
+          target: {
+            section: "personalProjects",
+            itemId: projectId,
+            field: null,
+            scope: "single_item",
+          },
+          draft: null,
+          warnings: [],
+        })
+        return
+      }
+
+      if (requestCount === 2) {
+        expect(payload.message).toBe("cancel")
+        expect(payload.pendingAction).toEqual({
+          type: "delete",
+          targetSection: "personalProjects",
+          targetItemIds: [projectId],
+        })
+        expect(payload.userDecision).toBe("reject")
+
+        await fulfillJson(route, 200, {
+          provider: "pollination",
+          mode: "exact_edit",
+          reply: "Canceled. I did not delete that project.",
+          status: "blocked",
+          clarificationQuestion: null,
+          needsClarification: false,
+          needsConfirmation: false,
+          readyToApply: false,
+          target: {
+            section: null,
+            itemId: null,
+            field: null,
+            scope: "unknown",
+          },
+          draft: null,
+          warnings: [],
+        })
+        return
+      }
+
+      expect(payload.message).toBe("Make my summary sharper.")
+      expect(payload.pendingAction).toBeUndefined()
+      expect(payload.userDecision).toBeUndefined()
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "exact_edit",
+        reply: "I can help with your summary.",
+        status: "blocked",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: false,
+        readyToApply: false,
+        target: {
+          section: "personalDetails",
+          itemId: null,
+          field: "summary",
+          scope: "section",
+        },
+        draft: null,
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await page.getByRole("button", { name: "Personal Project" }).click()
+    await page.getByRole("button", { name: "Add an item" }).click()
+    await page.getByLabel("Project name").fill("Forecast Me")
+
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill("Delete Forecast Me.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await expect(page.getByTestId("chat-message-bubble").filter({
+      hasText: "Do you want to permanently delete Forecast Me from Personal projects?",
+    })).toBeVisible()
+
+    await page.getByRole("textbox", { name: "Message" }).fill("cancel")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await expect(page.getByText("Canceled. I did not delete that project.")).toBeVisible()
+    await expect(page.getByRole("button", { name: "Accept" })).toHaveCount(0)
+
+    await page.getByRole("textbox", { name: "Message" }).fill("Make my summary sharper.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await expect(page.getByText("I can help with your summary.")).toBeVisible()
+    expect(requestCount).toBe(3)
+  })
+
+  test("persists pendingAction across reload before sending a confirmation decision", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    let requestCount = 0
+    let certificateId = ""
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON()
+
+      if (requestCount === 1) {
+        expect(payload.message).toBe("Delete all certificates.")
+        certificateId = payload.resumeData.certificates[0].id
+
+        await fulfillJson(route, 200, {
+          provider: "pollination",
+          mode: "exact_edit",
+          reply: "Do you want to permanently delete all Certificates?",
+          status: "clarification_needed",
+          clarificationQuestion: "Do you want to permanently delete all Certificates?",
+          needsClarification: true,
+          needsConfirmation: false,
+          readyToApply: false,
+          target: {
+            section: "certificates",
+            itemId: null,
+            field: null,
+            scope: "section",
+          },
+          draft: null,
+          warnings: [],
+        })
+        return
+      }
+
+      expect(payload.message).toBe("confirm")
+      expect(payload.pendingAction).toEqual({
+        type: "delete",
+        targetSection: "certificates",
+        targetItemIds: [certificateId],
+      })
+      expect(payload.userDecision).toBe("confirm")
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "exact_edit",
+        reply: "Draft ready to clear Certificates.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "certificates",
+          itemId: null,
+          field: null,
+          scope: "section",
+        },
+        draft: {
+          summary: "Clear Certificates.",
+          proposedChanges: [
+            {
+              section: "certificates",
+              itemId: null,
+              field: null,
+              instruction: "Remove all certificates.",
+              proposedText: "[]",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await page.getByRole("button", { name: "Certificate" }).click()
+    await page.getByRole("button", { name: "Add an item" }).click()
+    await page.getByLabel("Name").fill("Responsive Web Design")
+
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill("Delete all certificates.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await expect(page.getByTestId("chat-message-bubble").filter({
+      hasText: "Do you want to permanently delete all Certificates?",
+    })).toBeVisible()
+
+    await page.reload()
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill("confirm")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await expect(page.getByText("Draft ready to clear Certificates.")).toBeVisible()
+    expect(requestCount).toBe(2)
+  })
+
+  test("clears pendingAction when the next message is not a confirmation decision", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    let requestCount = 0
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON()
+
+      if (requestCount === 1) {
+        expect(payload.message).toBe("Delete all personal projects.")
+
+        await fulfillJson(route, 200, {
+          provider: "pollination",
+          mode: "exact_edit",
+          reply: "Do you want to permanently delete all Personal projects?",
+          status: "clarification_needed",
+          clarificationQuestion: "Do you want to permanently delete all Personal projects?",
+          needsClarification: true,
+          needsConfirmation: false,
+          readyToApply: false,
+          target: {
+            section: "personalProjects",
+            itemId: null,
+            field: null,
+            scope: "section",
+          },
+          draft: null,
+          warnings: [],
+        })
+        return
+      }
+
+      expect(payload.message).toBe("Update my summary instead.")
+      expect(payload.pendingAction).toBeUndefined()
+      expect(payload.userDecision).toBeUndefined()
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "exact_edit",
+        reply: "I can help update your summary instead.",
+        status: "blocked",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: false,
+        readyToApply: false,
+        target: {
+          section: "personalDetails",
+          itemId: null,
+          field: "summary",
+          scope: "section",
+        },
+        draft: null,
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill("Delete all personal projects.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await expect(page.getByTestId("chat-message-bubble").filter({
+      hasText: "Do you want to permanently delete all Personal projects?",
+    })).toBeVisible()
+
+    await page.getByRole("textbox", { name: "Message" }).fill("Update my summary instead.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await expect(page.getByText("I can help update your summary instead.")).toBeVisible()
+    expect(requestCount).toBe(2)
+  })
+
+  test("renders friendly field labels while keeping conversation payloads raw", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    let requestCount = 0
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON()
+      expect(payload.debugProvider).toBeUndefined()
+      expect(payload.conversationContext).toBeUndefined()
+
+      if (requestCount === 1) {
+        expect(payload.message).toBe("Show me the schema labels cleanly.")
+        expect(payload.conversation).toBeUndefined()
+        expect(payload.activeDraft).toBeUndefined()
+
+        await fulfillJson(route, 200, {
+          provider: "pollination",
+          mode: "exact_edit",
+          reply: "I can update personalDetails.summary, briefSummary, bulletSummary, knownLanguages, and devFramework.",
+          status: "draft_ready",
+          clarificationQuestion: null,
+          needsClarification: false,
+          needsConfirmation: true,
+          readyToApply: false,
+          target: {
+            section: "personalDetails",
+            itemId: null,
+            field: "summary",
+            scope: "resume_wide",
+          },
+          draft: {
+            summary: "Replace personalDetails.summary and devFramework references.",
+            proposedChanges: [
+              {
+                section: "personalDetails",
+                itemId: null,
+                field: "summary",
+                instruction: "Replace the summary with the reviewed draft.",
+                proposedText: "A polished frontend developer summary.",
+              },
+            ],
+          },
+          warnings: ["Check defaultPhoneNumber and socialGithub before applying."],
+        })
+        return
+      }
+
+      expect(payload.message).toBe("Use that draft but shorter.")
+      expect(payload.conversation).toEqual([
+        { role: "user", text: "Show me the schema labels cleanly." },
+        {
+          role: "assistant",
+          text: "I can update personalDetails.summary, briefSummary, bulletSummary, knownLanguages, and devFramework.",
+        },
+      ])
+      expect(payload.activeDraft?.draft.summary).toBe("Replace personalDetails.summary and devFramework references.")
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "grounded_suggestion",
+        reply: "I can revise that draft.",
+        status: "blocked",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: false,
+        readyToApply: false,
+        target: {
+          section: "personalDetails",
+          itemId: null,
+          field: "summary",
+          scope: "resume_wide",
+        },
+        draft: null,
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await openChatAssistant(page)
+
+    await page.getByRole("textbox", { name: "Message" }).fill("Show me the schema labels cleanly.")
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    const assistantBubble = page.locator(".chat-bubble").filter({
+      hasText: "I can update About me, Description, Bullet points, Languages, and Skills.",
+    })
+    await expect(assistantBubble).toBeVisible()
+    await expect(page.locator(".chat-bubble").filter({ hasText: "personalDetails.summary" })).toHaveCount(0)
+    await expect(page.getByText("Check Phone number and GitHub before applying.")).toBeVisible()
+
+    const reviewCard = page.getByText("Replace About me and Skills references.").locator("..")
+    await expect(reviewCard.getByTestId("chat-draft-breadcrumbs")).toContainText("Personal details")
+    await expect(reviewCard.getByTestId("chat-draft-breadcrumbs")).toContainText("About me")
+    await expect(reviewCard).not.toContainText("Updating:")
+    await expect(reviewCard).not.toContainText("personalDetails.summary")
+    await expect(reviewCard).not.toContainText("devFramework")
+
+    await page.getByRole("textbox", { name: "Message" }).fill("Use that draft but shorter.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await expect(page.getByText("I can revise that draft.")).toBeVisible()
+    expect(requestCount).toBe(2)
+  })
+
+  test("replaces active draft review content with centered loading during follow-up sends", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    let requestCount = 0
+    let releaseSecondResponse: (() => void) | null = null
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+
+      if (requestCount === 1) {
+        await fulfillJson(route, 200, {
+          provider: "pollination",
+          mode: "exact_edit",
+          reply: "I drafted a summary update.",
+          status: "draft_ready",
+          clarificationQuestion: null,
+          needsClarification: false,
+          needsConfirmation: true,
+          readyToApply: false,
+          target: {
+            section: "personalDetails",
+            itemId: null,
+            field: "summary",
+            scope: "resume_wide",
+          },
+          draft: {
+            summary: "Rewrite the About me summary.",
+            proposedChanges: [
+              {
+                section: "personalDetails",
+                itemId: null,
+                field: "summary",
+                instruction: "Replace the summary with a concise draft.",
+                proposedText: "Concise frontend developer summary.",
+              },
+            ],
+          },
+          warnings: [],
+        })
+        return
+      }
+
+      await new Promise<void>((resolve) => {
+        releaseSecondResponse = resolve
+      })
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "exact_edit",
+        reply: "I revised the draft.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "personalDetails",
+          itemId: null,
+          field: "summary",
+          scope: "resume_wide",
+        },
+        draft: {
+          summary: "Rewrite the About me summary with a shorter version.",
+          proposedChanges: [
+            {
+              section: "personalDetails",
+              itemId: null,
+              field: "summary",
+              instruction: "Replace the summary with a shorter draft.",
+              proposedText: "Short frontend developer summary.",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await openChatAssistant(page)
+
+    await page.getByRole("textbox", { name: "Message" }).fill("Improve my summary.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await expect(page.getByTestId("chat-draft-review")).toContainText("Rewrite the About me summary.")
+    await expect(page.getByRole("button", { name: "Accept" })).toBeVisible()
+
+    await page.getByRole("textbox", { name: "Message" }).fill("Make it shorter.")
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    const reviewCard = page.getByTestId("chat-draft-review")
+    await expect(reviewCard.getByTestId("chat-draft-loading")).toBeVisible()
+    await expect(reviewCard).toContainText("Updating draft")
+    await expect(reviewCard).not.toContainText("Rewrite the About me summary.")
+    await expect(page.getByRole("button", { name: "Accept" })).toHaveCount(0)
+    await expect(page.getByRole("button", { name: "Reject" })).toHaveCount(0)
+
+    releaseSecondResponse?.()
+    await expect(page.getByText("I revised the draft.")).toBeVisible()
+    expect(requestCount).toBe(2)
+  })
+
+  test("requires confirmation to clear local history", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "grounded_suggestion",
+        reply: "Let’s tighten your project description.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: false,
+        readyToApply: false,
+        target: {
+          section: "personalDetails",
+          itemId: null,
+          field: "summary",
+          scope: "resume_wide",
+        },
+        draft: null,
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await openChatAssistant(page)
+
+    await page.getByRole("textbox", { name: "Message" }).fill("Tighten this up.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await expect(page.getByText("Let’s tighten your project description.")).toBeVisible()
+
+    await page.getByRole("button", { name: "Clear conversation" }).click()
+    await expect(page.getByRole("heading", { name: "Clear conversation?" })).toBeVisible()
+    await page.getByRole("button", { name: "Cancel" }).click()
+    await expect(page.getByText("Let’s tighten your project description.")).toBeVisible()
+
+    await page.getByRole("button", { name: "Clear conversation" }).click()
+    await page.getByRole("button", { name: "Clear chat" }).click()
+    await expect(page.getByText("Ask to add, edit, or remove content in one specific section at a time.")).toBeVisible()
+  })
+
+  test("reject keeps the draft local only and leaves resume data unchanged", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    let requestCount = 0
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON()
+
+      if (requestCount === 1) {
+        expect(payload.activeDraft).toBeUndefined()
+        expect(payload.conversation).toBeUndefined()
+        expect(payload.conversationContext).toBeUndefined()
+        await fulfillJson(route, 200, {
+          provider: "pollination",
+          mode: "exact_edit",
+          reply: "I drafted a stronger summary for review.",
+          status: "draft_ready",
+          clarificationQuestion: null,
+          needsClarification: false,
+          needsConfirmation: true,
+          readyToApply: false,
+          target: {
+            section: "personalDetails",
+            itemId: null,
+            field: "summary",
+            scope: "resume_wide",
+          },
+          draft: {
+            summary: "A clearer summary draft is ready.",
+            proposedChanges: [
+              {
+                section: "personalDetails",
+                itemId: null,
+                field: "summary",
+                instruction: "Replace the summary with the reviewed draft.",
+                proposedText: "Product-minded frontend developer building polished resume tools.",
+              },
+            ],
+          },
+          warnings: [],
+        })
+        return
+      }
+
+      expect(payload.message).toBe("Improve my summary again.")
+      expect(payload.activeDraft).toBeUndefined()
+      expect(payload.conversation).toEqual([
+        { role: "user", text: "Improve my summary." },
+        { role: "assistant", text: "I drafted a stronger summary for review." },
+        {
+          role: "assistant",
+          text: "This draft is still not applied. Let me know if you want to add something or if you've changed your mind.",
+        },
+      ])
+      expect(payload.conversationContext).toBeUndefined()
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "grounded_suggestion",
+        reply: "Let’s try another summary draft.",
+        status: "blocked",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: false,
+        readyToApply: false,
+        target: {
+          section: "personalDetails",
+          itemId: null,
+          field: "summary",
+          scope: "resume_wide",
+        },
+        draft: null,
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await page.getByRole("button", { name: "About you" }).click()
+
+    const summaryInput = page.getByLabel("Summary")
+    await summaryInput.fill("Original summary")
+
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill("Improve my summary.")
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    await expect(page.getByRole("button", { name: "Reject" })).toBeVisible()
+    await expect(page.getByRole("button", { name: "Accept" })).toBeVisible()
+
+    await page.getByRole("button", { name: "Reject" }).click()
+    await expect(summaryInput).toHaveValue("Original summary")
+    await expect(page.getByText("This draft is still not applied")).toBeVisible()
+    await expect(page.getByRole("button", { name: "Accept" })).toHaveCount(0)
+
+    await page.getByRole("textbox", { name: "Message" }).fill("Improve my summary again.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await expect(page.getByText("Let’s try another summary draft.")).toBeVisible()
+    expect(requestCount).toBe(2)
+  })
+
+  test("accept applies the displayed draft locally without a second backend request", async ({ page }) => {
+    let requestCount = 0
+
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON()
+      expect(payload.activeDraft).toBeUndefined()
+      expect(payload.conversation).toBeUndefined()
+      expect(payload.conversationContext).toBeUndefined()
+      expect(payload.debugProvider).toBeUndefined()
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "exact_edit",
+        reply: "I drafted a stronger summary for review.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "personalDetails",
+          itemId: null,
+          field: "summary",
+          scope: "resume_wide",
+        },
+        draft: {
+          summary: "A clearer summary draft is ready.",
+          proposedChanges: [
+            {
+              section: "personalDetails",
+              itemId: null,
+              field: "summary",
+              instruction: "Replace the summary with the reviewed draft.",
+              proposedText: "Product-minded frontend developer building polished resume tools.",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await page.getByRole("button", { name: "About you" }).click()
+
+    const summaryInput = page.getByLabel("Summary")
+    await summaryInput.fill("Original summary")
+
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill("Improve my summary.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await expect(page.getByRole("button", { name: "Accept" })).toBeVisible()
+    await expect(page.getByRole("button", { name: "Reject" })).toBeVisible()
+
+    await page.getByRole("button", { name: "Accept" }).click()
+    await expect(summaryInput).toHaveValue("Product-minded frontend developer building polished resume tools.")
+    await expect(page.getByText("I drafted a stronger summary for review.")).toBeVisible()
+    await expect(page.getByText("Done. I applied that update to your resume. What would you like to improve next?")).toBeVisible()
+    await expect(page.getByRole("button", { name: "Accept" })).toHaveCount(0)
+    await expect(page.getByRole("button", { name: "Reject" })).toHaveCount(0)
+    await expect(page.getByText("A clearer summary draft is ready.")).toHaveCount(0)
+    await expect(page.getByRole("textbox", { name: "Message" })).toHaveAttribute("placeholder", "Please be gentle to your assistant.")
+    expect(requestCount).toBe(1)
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON()
+
+      expect(payload.message).toBe("Improve my summary again.")
+      expect(payload.activeDraft).toBeUndefined()
+      expect(payload.conversation).toEqual([
+        { role: "user", text: "Improve my summary." },
+        { role: "assistant", text: "I drafted a stronger summary for review." },
+        {
+          role: "assistant",
+          text: "Done. I applied that update to your resume. What would you like to improve next?",
+        },
+      ])
+      expect(payload.conversationContext).toBeUndefined()
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "grounded_suggestion",
+        reply: "Ready for another summary update.",
+        status: "blocked",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: false,
+        readyToApply: false,
+        target: {
+          section: "personalDetails",
+          itemId: null,
+          field: "summary",
+          scope: "resume_wide",
+        },
+        draft: null,
+        warnings: [],
+      })
+    }, { times: 1 })
+
+    await page.getByRole("textbox", { name: "Message" }).fill("Improve my summary again.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await expect(page.getByText("Ready for another summary update.")).toBeVisible()
+    expect(requestCount).toBe(2)
+  })
+
+  test("auto-improved backend wording previews and applies without frontend quality flags", async ({ page }) => {
+    const improvedSummary =
+      "Frontend developer focused on building accessible, reliable user experiences with clear product impact."
+    const exactSummary = "I build stuff with care."
+    const improvedProjectDescription =
+      "Portfolio website showcasing polished UI work, responsive layouts, and practical frontend delivery."
+    const improvedWorkBullets = [
+      "Built AI-assisted workflow tools that improved development consistency.",
+      "Delivered responsive web interfaces that made key tasks easier for users.",
+    ]
+    const improvedCertificateDescription =
+      "Completed foundational computer science coursework covering programming concepts, algorithms, and problem-solving fundamentals."
+    const improvedAchievementDescription =
+      "Recognized for sustained academic performance and consistent delivery of high-quality coursework."
+
+    const responses = [
+      {
+        message: "Make my about me professional from: i make apps good.",
+        reply: "Draft ready with a stronger About Me.",
+        target: { section: "personalDetails", itemId: null, field: "summary", scope: "resume_wide" },
+        draftSummary: "Improve the About Me summary.",
+        proposedChanges: [
+          {
+            section: "personalDetails",
+            itemId: null,
+            field: "summary",
+            instruction: "Replace rough summary wording with an ATS-friendly version.",
+            proposedText: improvedSummary,
+          },
+        ],
+      },
+      {
+        message: "Keep the exact wording: I build stuff with care.",
+        reply: "Draft ready using the exact wording you provided.",
+        target: { section: "personalDetails", itemId: null, field: "summary", scope: "resume_wide" },
+        draftSummary: "Use the exact About Me wording.",
+        proposedChanges: [
+          {
+            section: "personalDetails",
+            itemId: null,
+            field: "summary",
+            instruction: "Replace summary while preserving the user's exact wording.",
+            proposedText: exactSummary,
+          },
+        ],
+      },
+      {
+        message: "Add a rough project called Atlas, it is portfolio, description is made portfolio site.",
+        reply: "Draft ready to add an improved Atlas project.",
+        target: { section: "personalProjects", itemId: null, field: null, scope: "section" },
+        draftSummary: "Create a new Atlas project item.",
+        proposedChanges: [
+          {
+            section: "personalProjects",
+            itemId: null,
+            field: null,
+            instruction: "Add a new project item with improved description wording.",
+            proposedText: JSON.stringify({
+              projectName: "Atlas",
+              projectSubtitle: "Portfolio Website",
+              preview: "",
+              briefSummary: improvedProjectDescription,
+              bulletType: false,
+              bulletSummary: [],
+            }),
+          },
+        ],
+      },
+      {
+        message: "Add work at Northstar Labs as Frontend Developer with rough bullets.",
+        reply: "Draft ready to add improved work bullets.",
+        target: { section: "workExperiences", itemId: null, field: null, scope: "section" },
+        draftSummary: "Create a new Northstar Labs work experience.",
+        proposedChanges: [
+          {
+            section: "workExperiences",
+            itemId: null,
+            field: null,
+            instruction: "Add a work item with improved bullet content.",
+            proposedText: JSON.stringify({
+              companyName: "Northstar Labs",
+              jobTitle: "Frontend Developer",
+              briefSummary: "",
+              startYear: "2025",
+              endYear: "present",
+              currentlyHired: true,
+              bulletType: true,
+              bulletSummary: improvedWorkBullets,
+            }),
+          },
+        ],
+      },
+      {
+        message: "Add CS50 certificate with description related to the title.",
+        reply: "Draft ready to add an improved certificate description.",
+        target: { section: "certificates", itemId: null, field: null, scope: "section" },
+        draftSummary: "Create a new CS50 certificate item.",
+        proposedChanges: [
+          {
+            section: "certificates",
+            itemId: null,
+            field: null,
+            instruction: "Add a certificate item with an improved description.",
+            proposedText: JSON.stringify({
+              certificateName: "CS50x: Introduction to Computer Science",
+              certificateIssuer: "HarvardX",
+              yearIssued: "January 2025",
+              certificateDescription: improvedCertificateDescription,
+            }),
+          },
+        ],
+      },
+      {
+        message: "Add academic excellence achievement with description related to the award.",
+        reply: "Draft ready to add an improved achievement description.",
+        target: { section: "achievements", itemId: null, field: null, scope: "section" },
+        draftSummary: "Create a new Academic Excellence achievement item.",
+        proposedChanges: [
+          {
+            section: "achievements",
+            itemId: null,
+            field: null,
+            instruction: "Add an achievement item with an improved description.",
+            proposedText: JSON.stringify({
+              achievementName: "Academic Excellence",
+              achievementIssuer: "Harvard",
+              yearIssued: "November 2024",
+              achievementDescription: improvedAchievementDescription,
+            }),
+          },
+        ],
+      },
+    ] as const
+    let requestCount = 0
+
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      const response = responses[requestCount]
+      requestCount += 1
+      const payload = route.request().postDataJSON() as Record<string, unknown>
+
+      expect(payload.message).toBe(response.message)
+      expect(payload.conversationContext).toBeUndefined()
+      expect(payload.activeDraft).toBeUndefined()
+      expect(payload.debugProvider).toBeUndefined()
+      expectNoAutoImproveRequestFields(payload)
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "grounded_suggestion",
+        reply: response.reply,
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: response.target,
+        draft: {
+          summary: response.draftSummary,
+          proposedChanges: response.proposedChanges,
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await page.getByRole("button", { name: "About you" }).click()
+
+    const summaryInput = page.getByLabel("Summary")
+    await summaryInput.fill("i make apps good")
+
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill(responses[0].message)
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    let reviewCard = page.getByTestId("chat-draft-review")
+    await expect(reviewCard).toContainText(improvedSummary)
+    await expect(reviewCard).not.toContainText("i make apps good")
+    await page.getByRole("button", { name: "Accept" }).click()
+    await expect(summaryInput).toHaveValue(improvedSummary)
+
+    await page.getByRole("textbox", { name: "Message" }).fill(responses[1].message)
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    reviewCard = page.getByTestId("chat-draft-review")
+    await expect(reviewCard).toContainText(exactSummary)
+    await page.getByRole("button", { name: "Accept" }).click()
+    await expect(summaryInput).toHaveValue(exactSummary)
+
+    await page.getByRole("textbox", { name: "Message" }).fill(responses[2].message)
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    reviewCard = page.getByTestId("chat-draft-review")
+    await expect(reviewCard).toContainText(improvedProjectDescription)
+    await expect(reviewCard).not.toContainText("made portfolio site")
+    await page.getByRole("button", { name: "Accept" }).click()
+
+    await page.keyboard.press("Escape")
+    await page.getByRole("button", { name: "Personal Project" }).click()
+    await expect(page.getByRole("button", { name: "Atlas Portfolio Website" })).toBeVisible()
+    await expect(page.getByLabel("Brief summary")).toHaveValue(improvedProjectDescription)
+
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill(responses[3].message)
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    reviewCard = page.getByTestId("chat-draft-review")
+    for (const bullet of improvedWorkBullets) {
+      await expect(reviewCard).toContainText(bullet)
+    }
+    await expect(reviewCard).not.toContainText("rough bullets")
+    await page.getByRole("button", { name: "Accept" }).click()
+
+    await page.keyboard.press("Escape")
+    await page.getByRole("button", { name: "Work Experience" }).click()
+    await expect(page.getByRole("button", { name: "Frontend Developer Northstar Labs" })).toBeVisible()
+    await expect(page.getByLabel("Use bullet points")).toBeChecked()
+    const bulletRows = page.getByTestId("bullet-row")
+    await expect(bulletRows.first().getByRole("textbox")).toHaveValue(improvedWorkBullets[0])
+    await expect(bulletRows.nth(1).getByRole("textbox")).toHaveValue(improvedWorkBullets[1])
+
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill(responses[4].message)
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    reviewCard = page.getByTestId("chat-draft-review")
+    await expect(reviewCard).toContainText(improvedCertificateDescription)
+    await expect(reviewCard).not.toContainText("CS50x: Introduction to Computer Science coursework (HarvardX) in January 2025.")
+    await page.getByRole("button", { name: "Accept" }).click()
+
+    await page.keyboard.press("Escape")
+    await page.getByRole("button", { name: "Certificate" }).click()
+    await expect(page.getByRole("button", { name: "CS50x: Introduction to Computer Science HarvardX" })).toBeVisible()
+    await expect(page.getByLabel("Description")).toHaveValue(improvedCertificateDescription)
+
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill(responses[5].message)
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    reviewCard = page.getByTestId("chat-draft-review")
+    await expect(reviewCard).toContainText(improvedAchievementDescription)
+    await expect(reviewCard).not.toContainText("Academic Excellence Harvard November 2024")
+    await page.getByRole("button", { name: "Accept" }).click()
+
+    await page.keyboard.press("Escape")
+    await page.getByRole("button", { name: "Achievement" }).click()
+    await expect(page.getByRole("button", { name: "Academic Excellence" })).toBeVisible()
+    await expect(page.getByLabel("Description")).toHaveValue(improvedAchievementDescription)
+    expect(requestCount).toBe(responses.length)
+  })
+
+  test("accepted coreSkills drafts do not anchor the next unrelated Kaizer bullet request", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    let requestCount = 0
+    let kaizerId = ""
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON() as Record<string, unknown>
+
+      if (requestCount === 1) {
+        expect(payload.message).toBe("Create a Testing core skill group.")
+        expectNoActiveBoundaryState(payload)
+        expect(payload.conversation).toBeUndefined()
+        expect(payload.conversationContext).toBeUndefined()
+
+        await fulfillJson(route, 200, {
+          provider: "pollination",
+          mode: "exact_edit",
+          reply: "I drafted a new Testing core skill group for review.",
+          status: "draft_ready",
+          clarificationQuestion: null,
+          needsClarification: false,
+          needsConfirmation: true,
+          readyToApply: false,
+          target: {
+            section: "coreSkills",
+            itemId: null,
+            field: null,
+            scope: "section",
+          },
+          draft: {
+            summary: "Create a new Testing core skill group.",
+            proposedChanges: [
+              {
+                section: "coreSkills",
+                itemId: null,
+                field: null,
+                instruction: "Create the Testing core skill group with the provided tools.",
+                proposedText: "{\"devLanguage\":\"Testing\",\"devFramework\":[\"Jest\",\"Playwright\"]}",
+              },
+            ],
+          },
+          warnings: [],
+        })
+        return
+      }
+
+      expect(payload.message).toBe("I want to add Kaizer a bullet point that it uses Codex for implementation and development")
+      expectNoActiveBoundaryState(payload)
+      expect(payload.conversationContext).toBeUndefined()
+      expect(payload.conversation).toEqual([
+        { role: "user", text: "Create a Testing core skill group." },
+        { role: "assistant", text: "I drafted a new Testing core skill group for review." },
+        { role: "assistant", text: "Done. I applied that update to your resume. What would you like to improve next?" },
+      ])
+      expect(Array.isArray(payload.resumeData.personalProjects)).toBe(true)
+      expect(payload.resumeData.personalProjects).toHaveLength(1)
+      kaizerId = (payload.resumeData.personalProjects as Array<{ id: string; projectName: string }>)[0].id
+      expect((payload.resumeData.personalProjects as Array<{ projectName: string }>)[0].projectName).toBe("Kaizer")
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "exact_edit",
+        reply: "I drafted a Kaizer bullet for review.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "personalProjects",
+          itemId: kaizerId,
+          field: "bulletSummary",
+          scope: "single_item",
+        },
+        draft: {
+          summary: "Add Codex usage bullet to Kaizer project.",
+          proposedChanges: [
+            {
+              section: "personalProjects",
+              itemId: kaizerId,
+              field: "bulletSummary",
+              instruction: "Add the new Codex-related bullet to Kaizer.",
+              proposedText: "Used Codex to support implementation and development workflows.",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await page.getByRole("button", { name: "Personal Project" }).click()
+    await page.getByRole("button", { name: "Add an item" }).click()
+    await page.getByLabel("Project name").fill("Kaizer")
+
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill("Create a Testing core skill group.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await page.getByRole("button", { name: "Accept" }).click()
+    await expect(page.getByText("Done. I applied that update to your resume. What would you like to improve next?")).toBeVisible()
+    await expect(page.getByRole("button", { name: "Accept" })).toHaveCount(0)
+
+    await page.getByRole("textbox", { name: "Message" }).fill("I want to add Kaizer a bullet point that it uses Codex for implementation and development")
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    const reviewCard = page.getByTestId("chat-draft-review")
+    await expect(reviewCard).toContainText("Add Codex usage bullet to Kaizer project.")
+    await expect(reviewCard).toContainText("Used Codex to support implementation and development workflows.")
+    await expect(reviewCard.getByTestId("chat-draft-breadcrumbs")).toContainText("Personal projects")
+    expect(requestCount).toBe(2)
+  })
+
+  test("accepted project drafts do not reuse stale active draft state for the next new-project request", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    let requestCount = 0
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON() as Record<string, unknown>
+
+      if (requestCount === 1) {
+        expect(payload.message).toBe("I want to add a new project.")
+        expectNoActiveBoundaryState(payload)
+        expect(payload.conversation).toBeUndefined()
+        expect(payload.conversationContext).toBeUndefined()
+
+        await fulfillJson(route, 200, {
+          provider: "pollination",
+          mode: "grounded_suggestion",
+          reply: "Draft ready to add a new Atlas project.",
+          status: "draft_ready",
+          clarificationQuestion: null,
+          needsClarification: false,
+          needsConfirmation: true,
+          readyToApply: false,
+          target: {
+            section: "personalProjects",
+            itemId: null,
+            field: null,
+            scope: "section",
+          },
+          draft: {
+            summary: "Create a new Atlas project item.",
+            proposedChanges: [
+              {
+                section: "personalProjects",
+                itemId: null,
+                field: null,
+                instruction: "Add the new Atlas project.",
+                proposedText: "{\"projectName\":\"Atlas\",\"projectSubtitle\":\"Portfolio Website\",\"preview\":\"\",\"briefSummary\":\"Portfolio site for selected frontend work.\",\"bulletType\":false,\"bulletSummary\":[]}",
+              },
+            ],
+          },
+          warnings: [],
+        })
+        return
+      }
+
+      expect(payload.message).toBe("I want to add another new project named Nova.")
+      expectNoActiveBoundaryState(payload)
+      expect(payload.conversationContext).toBeUndefined()
+      expect(payload.conversation).toEqual([
+        { role: "user", text: "I want to add a new project." },
+        { role: "assistant", text: "Draft ready to add a new Atlas project." },
+        { role: "assistant", text: "Done. I applied that update to your resume. What would you like to improve next?" },
+      ])
+      expect(Array.isArray(payload.resumeData.personalProjects)).toBe(true)
+      expect(payload.resumeData.personalProjects).toHaveLength(1)
+      expect((payload.resumeData.personalProjects as Array<{ projectName: string }>)[0].projectName).toBe("Atlas")
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "grounded_suggestion",
+        reply: "Draft ready to add a new Nova project.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "personalProjects",
+          itemId: null,
+          field: null,
+          scope: "section",
+        },
+        draft: {
+          summary: "Create a new Nova project item.",
+          proposedChanges: [
+            {
+              section: "personalProjects",
+              itemId: null,
+              field: null,
+              instruction: "Add the new Nova project.",
+              proposedText: "{\"projectName\":\"Nova\",\"projectSubtitle\":\"Weather App\",\"preview\":\"\",\"briefSummary\":\"Weather app for daily forecasts.\",\"bulletType\":false,\"bulletSummary\":[]}",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await page.getByRole("button", { name: "Personal Project" }).click()
+
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill("I want to add a new project.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await page.getByRole("button", { name: "Accept" }).click()
+    await expect(page.getByText("Done. I applied that update to your resume. What would you like to improve next?")).toBeVisible()
+
+    await page.getByRole("textbox", { name: "Message" }).fill("I want to add another new project named Nova.")
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    const reviewCard = page.getByTestId("chat-draft-review")
+    await expect(reviewCard).toContainText("Create a new Nova project item.")
+    await expect(reviewCard).toContainText("Nova")
+    await expect(reviewCard).not.toContainText("Atlas")
+    expect(requestCount).toBe(2)
+  })
+
+  test("rejected drafts do not send stale active state on the next unrelated request", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    let requestCount = 0
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON() as Record<string, unknown>
+
+      if (requestCount === 1) {
+        expect(payload.message).toBe("Improve my summary.")
+        expectNoActiveBoundaryState(payload)
+        expect(payload.conversation).toBeUndefined()
+        expect(payload.conversationContext).toBeUndefined()
+
+        await fulfillJson(route, 200, {
+          provider: "pollination",
+          mode: "exact_edit",
+          reply: "I drafted a stronger summary for review.",
+          status: "draft_ready",
+          clarificationQuestion: null,
+          needsClarification: false,
+          needsConfirmation: true,
+          readyToApply: false,
+          target: {
+            section: "personalDetails",
+            itemId: null,
+            field: "summary",
+            scope: "resume_wide",
+          },
+          draft: {
+            summary: "A clearer summary draft is ready.",
+            proposedChanges: [
+              {
+                section: "personalDetails",
+                itemId: null,
+                field: "summary",
+                instruction: "Replace the summary with the reviewed draft.",
+                proposedText: "Product-minded frontend developer building polished resume tools.",
+              },
+            ],
+          },
+          warnings: [],
+        })
+        return
+      }
+
+      expect(payload.message).toBe("Add a Testing core skill group.")
+      expectNoActiveBoundaryState(payload)
+      expect(payload.conversationContext).toBeUndefined()
+      expect(payload.conversation).toEqual([
+        { role: "user", text: "Improve my summary." },
+        { role: "assistant", text: "I drafted a stronger summary for review." },
+        { role: "assistant", text: "This draft is still not applied. Let me know if you want to add something or if you've changed your mind." },
+      ])
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "grounded_suggestion",
+        reply: "Draft ready to create a new Testing core skill group.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "coreSkills",
+          itemId: null,
+          field: null,
+          scope: "section",
+        },
+        draft: {
+          summary: "Create a new Testing core skill group.",
+          proposedChanges: [
+            {
+              section: "coreSkills",
+              itemId: null,
+              field: null,
+              instruction: "Create the Testing core skill group with the provided tools.",
+              proposedText: "{\"devLanguage\":\"Testing\",\"devFramework\":[\"Jest\",\"Playwright\"]}",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await page.getByRole("button", { name: "About you" }).click()
+    await page.getByLabel("Summary").fill("Original summary")
+
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill("Improve my summary.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await page.getByRole("button", { name: "Reject" }).click()
+    await expect(page.getByText("This draft is still not applied")).toBeVisible()
+
+    await page.getByRole("textbox", { name: "Message" }).fill("Add a Testing core skill group.")
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    const reviewCard = page.getByTestId("chat-draft-review")
+    await expect(reviewCard).toContainText("Create a new Testing core skill group.")
+    await expect(reviewCard).toContainText("Jest, Playwright")
+    expect(requestCount).toBe(2)
+  })
+
+  test("accept applies empty-string drafts by clearing personal details summary", async ({ page }) => {
+    let requestCount = 0
+
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON()
+
+      expect(payload.message).toBe("delete about me")
+      expect(payload.activeDraft).toBeUndefined()
+      expect(payload.conversationContext).toBeUndefined()
+      expect(payload.debugProvider).toBeUndefined()
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "exact_edit",
+        reply: "Draft ready to delete your About Me (summary) from the resume.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "personalDetails",
+          itemId: null,
+          field: "summary",
+          scope: "section",
+        },
+        draft: {
+          summary: "Delete About Me/summary",
+          proposedChanges: [
+            {
+              section: "personalDetails",
+              itemId: null,
+              field: "summary",
+              instruction: "Clear the About Me/summary field",
+              proposedText: "",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await page.getByRole("button", { name: "About you" }).click()
+
+    const summaryInput = page.getByLabel("Summary")
+    await summaryInput.fill("Junior software developer focused on delivering clean, maintainable code.")
+
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill("delete about me")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await expect(page.getByRole("button", { name: "Accept" })).toBeVisible()
+
+    await page.getByRole("button", { name: "Accept" }).click()
+
+    await expect(summaryInput).toHaveValue("")
+    await expect(page.getByTestId("chat-inline-error")).toHaveCount(0)
+    await expect(page.getByText("Done. I applied that update to your resume. What would you like to improve next?")).toBeVisible()
+    expect(requestCount).toBe(1)
+  })
+
+  test("accept applies boolean field drafts like work-experience bulletType locally", async ({ page }) => {
+    let requestCount = 0
+    let workExperienceId = ""
+
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON()
+      expect(payload.activeDraft).toBeUndefined()
+      expect(payload.conversation).toBeUndefined()
+      expect(payload.conversationContext).toBeUndefined()
+      expect(payload.debugProvider).toBeUndefined()
+
+      expect(Array.isArray(payload.resumeData.workExperiences)).toBe(true)
+      expect(payload.resumeData.workExperiences).toHaveLength(1)
+
+      workExperienceId = payload.resumeData.workExperiences[0].id
+      expect(workExperienceId).toBeTruthy()
+      expect(payload.resumeData.workExperiences[0].jobTitle).toBe("Software Engineer")
+      expect(payload.resumeData.workExperiences[0].companyName).toBe("TerniLabs")
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "exact_edit",
+        reply: "Draft ready to enable bullet points for the selected work experience.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "workExperiences",
+          itemId: workExperienceId,
+          field: "bulletType",
+          scope: "single_item",
+        },
+        draft: {
+          summary: "Enable bullet points for the work experience item by turning on Use bullet points.",
+          proposedChanges: [
+            {
+              section: "workExperiences",
+              itemId: workExperienceId,
+              field: "bulletType",
+              instruction: "Turn on bullet points for this work experience item.",
+              proposedText: "true",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await page.getByRole("button", { name: "Work Experience" }).click()
+    await page.getByRole("button", { name: "Add an item" }).click()
+    await page.getByLabel("Position").fill("Software Engineer")
+    await page.getByLabel("Company").fill("TerniLabs")
+    await page.getByLabel("Brief summary").fill("Built internal product features.")
+
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill("Enable bullet points for this experience.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await expect(page.getByRole("button", { name: "Accept" })).toBeVisible()
+
+    await page.getByRole("button", { name: "Accept" }).click()
+
+    await expect(page.getByText("Done. I applied that update to your resume. What would you like to improve next?")).toBeVisible()
+    await expect(page.getByTestId("chat-inline-error")).toHaveCount(0)
+    await expect(page.getByLabel("Use bullet points")).toBeChecked()
+    await expect(page.getByTestId("bullet-list-panel")).toBeVisible()
+    await expect(page.getByLabel("Brief summary")).toHaveCount(0)
+    expect(requestCount).toBe(1)
+  })
+
+  test("accept applies remove-item drafts by deleting the targeted personal project locally", async ({ page }) => {
+    let requestCount = 0
+    let codexProjectId = ""
+    let forecastProjectId = ""
+
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON()
+      expect(payload.activeDraft).toBeUndefined()
+      expect(payload.conversation).toBeUndefined()
+      expect(payload.conversationContext).toBeUndefined()
+      expect(payload.debugProvider).toBeUndefined()
+
+      expect(Array.isArray(payload.resumeData.personalProjects)).toBe(true)
+      expect(payload.resumeData.personalProjects).toHaveLength(2)
+
+      codexProjectId =
+        payload.resumeData.personalProjects.find((item: { projectName: string }) => item.projectName === "Codex Skill")?.id ?? ""
+      forecastProjectId =
+        payload.resumeData.personalProjects.find((item: { projectName: string }) => item.projectName === "Forecast Me")?.id ?? ""
+
+      expect(codexProjectId).toBeTruthy()
+      expect(forecastProjectId).toBeTruthy()
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "exact_edit",
+        reply: "Draft ready to remove Codex Skill project from Personal projects.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "personalProjects",
+          itemId: codexProjectId,
+          field: null,
+          scope: "single_item",
+        },
+        draft: {
+          summary: "Remove Codex Skill project from Personal projects.",
+          proposedChanges: [
+            {
+              section: "personalProjects",
+              itemId: codexProjectId,
+              field: null,
+              instruction: "Remove the Codex Skill personal project item.",
+              proposedText: null,
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await page.getByRole("button", { name: "Personal Project" }).click()
+    await page.getByRole("button", { name: "Add an item" }).click()
+    await page.getByLabel("Project name").fill("Codex Skill")
+    await page.getByLabel("Project subtitle").fill("Agent skill")
+
+    await page.getByRole("button", { name: "Add an item" }).click()
+    await page.getByLabel("Project name").last().fill("Forecast Me")
+    await page.getByLabel("Project subtitle").last().fill("Weather Web Application")
+
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill("Remove Codex Skill.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await expect(page.getByRole("button", { name: "Accept" })).toBeVisible()
+
+    await page.getByRole("button", { name: "Accept" }).click()
+
+    await expect(page.getByText("Done. I applied that update to your resume. What would you like to improve next?")).toBeVisible()
+    await expect(page.getByTestId("chat-inline-error")).toHaveCount(0)
+    await expect(page.getByRole("button", { name: "Accept" })).toHaveCount(0)
+    await expect(page.getByRole("button", { name: "Reject" })).toHaveCount(0)
+
+    await page.keyboard.press("Escape")
+    await expect(page.getByRole("button", { name: "Codex Skill Agent skill" })).toHaveCount(0)
+    await expect(page.getByRole("button", { name: "Forecast Me Weather Web Application" })).toBeVisible()
+    expect(requestCount).toBe(1)
+  })
+
+  test("accept applies remove-item drafts globally when the backend sends an empty-array remove payload", async ({ page }) => {
+    let requestCount = 0
+    let coreSkillId = ""
+
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON()
+      expect(payload.activeDraft).toBeUndefined()
+      expect(payload.conversation).toBeUndefined()
+      expect(payload.conversationContext).toBeUndefined()
+      expect(payload.debugProvider).toBeUndefined()
+
+      expect(Array.isArray(payload.resumeData.coreSkills)).toBe(true)
+      expect(payload.resumeData.coreSkills).toHaveLength(1)
+
+      coreSkillId =
+        payload.resumeData.coreSkills.find((item: { devLanguage: string }) => item.devLanguage === "Codex")?.id ?? ""
+
+      expect(coreSkillId).toBeTruthy()
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "exact_edit",
+        reply: "Draft ready to remove Codex from Core Skills.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "coreSkills",
+          itemId: coreSkillId,
+          field: null,
+          scope: "section",
+        },
+        draft: {
+          summary: "Remove Codex core skill item.",
+          proposedChanges: [
+            {
+              section: "coreSkills",
+              itemId: coreSkillId,
+              field: null,
+              instruction: "Remove the Codex core skill item from the Core Skills array.",
+              proposedText: "[]",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await page.getByRole("button", { name: "Skill" }).click()
+    await page.getByRole("button", { name: "Add an item" }).click()
+    await page.getByLabel("Language").fill("Codex")
+    await page.keyboard.press(",")
+    await expect(page.getByRole("button", { name: "Codex" })).toBeVisible()
+
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill("I want to remove Codex in Core skill")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await expect(page.getByRole("button", { name: "Accept" })).toBeVisible()
+
+    await page.getByRole("button", { name: "Accept" }).click()
+
+    await expect(page.getByText("Done. I applied that update to your resume. What would you like to improve next?")).toBeVisible()
+    await expect(page.getByTestId("chat-inline-error")).toHaveCount(0)
+    await expect(page.getByRole("button", { name: "Accept" })).toHaveCount(0)
+    await expect(page.getByRole("button", { name: "Reject" })).toHaveCount(0)
+
+    await page.keyboard.press("Escape")
+    await expect(page.getByRole("button", { name: "Codex" })).toHaveCount(0)
+    expect(requestCount).toBe(1)
+  })
+
+  test("clarification-needed responses render the exact question in dedicated mode without draft actions", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "grounded_suggestion",
+        reply: "I can update briefSummary or bulletSummary once you confirm the target.",
+        status: "clarification_needed",
+        clarificationQuestion: "Which Kaizer project should I update? You can also tell me whether to edit briefSummary or bulletSummary.",
+        needsClarification: true,
+        needsConfirmation: false,
+        readyToApply: false,
+        target: {
+          section: "personalProjects",
+          itemId: "kaizer-project",
+          field: "bulletSummary",
+          scope: "single_item",
+        },
+        draft: null,
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await openChatAssistant(page)
+
+    await page.getByRole("textbox", { name: "Message" }).fill("Add something in Kaizer related to Codex usage.")
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    await expect(page.locator(".chat-bubble").filter({ hasText: "I can update Description or Bullet points once you confirm the target." })).toBeVisible()
+    await expect(page.locator(".chat-bubble").filter({ hasText: "briefSummary" })).toHaveCount(0)
+    await expect(page.getByText("Need details before I can continue")).toBeVisible()
+    await expect(page.getByText("Which Kaizer project should I update? You can also tell me whether to edit Description or Bullet points.")).toBeVisible()
+    await expect(page.getByText("Which Kaizer project should I update? You can also tell me whether to edit briefSummary or bulletSummary.")).toHaveCount(0)
+    await expect(page.getByRole("button", { name: "Accept" })).toHaveCount(0)
+    await expect(page.getByRole("button", { name: "Reject" })).toHaveCount(0)
+    await expect(page.getByRole("textbox", { name: "Message" })).toHaveAttribute("placeholder", "Answer the assistant's question to continue.")
+  })
+
+  test("clarification follow-up requests include recent conversation memory", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    let requestCount = 0
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON()
+
+      if (requestCount === 1) {
+        expect(payload.message).toBe("Add something in Kaizer related to Codex usage.")
+        expect(payload.activeDraft).toBeUndefined()
+        expect(payload.conversation).toBeUndefined()
+        expect(payload.conversationContext).toBeUndefined()
+        expect(payload.debugProvider).toBeUndefined()
+
+        await fulfillJson(route, 200, {
+          provider: "pollination",
+          mode: "grounded_suggestion",
+          reply: "I can update briefSummary or bulletSummary once you confirm the target.",
+          status: "clarification_needed",
+          clarificationQuestion: "Which Kaizer project should I update? You can also tell me whether to edit briefSummary or bulletSummary.",
+          needsClarification: true,
+          needsConfirmation: false,
+          readyToApply: false,
+          target: {
+            section: "personalProjects",
+            itemId: "kaizer-project",
+            field: "bulletSummary",
+            scope: "single_item",
+          },
+          draft: null,
+          warnings: [],
+        })
+        return
+      }
+
+      expect(payload.message).toBe("Update the bullet points.")
+      expect(payload.activeDraft).toBeUndefined()
+      expect(payload.conversation).toEqual([
+        { role: "user", text: "Add something in Kaizer related to Codex usage." },
+        { role: "assistant", text: "I can update briefSummary or bulletSummary once you confirm the target." },
+      ])
+      expect(payload.conversationContext).toBeUndefined()
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "grounded_suggestion",
+        reply: "I can help update those bullet points.",
+        status: "blocked",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: false,
+        readyToApply: false,
+        target: {
+          section: "personalProjects",
+          itemId: "kaizer-project",
+          field: "bulletSummary",
+          scope: "single_item",
+        },
+        draft: null,
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await openChatAssistant(page)
+
+    await page.getByRole("textbox", { name: "Message" }).fill("Add something in Kaizer related to Codex usage.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await page.getByRole("textbox", { name: "Message" }).fill("Update the bullet points.")
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    await expect(page.getByText("I can help update those bullet points.")).toBeVisible()
+    expect(requestCount).toBe(2)
+  })
+
+  test("core-skills create clarification persists recent conversation memory across reload", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    let requestCount = 0
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON()
+
+      if (requestCount === 1) {
+        expect(payload.message).toBe("Add something in Core skills for Testing.")
+        expect(payload.activeDraft).toBeUndefined()
+        expect(payload.conversation).toBeUndefined()
+        expect(payload.conversationContext).toBeUndefined()
+
+        await fulfillJson(route, 200, {
+          provider: "pollination",
+          mode: "grounded_suggestion",
+          reply: "I do not see a Testing core skill group yet.",
+          status: "clarification_needed",
+          clarificationQuestion: "I do not see a Testing core skill group yet. Do you want to create a new Testing group, or add the skill under an existing group like Database or Tools?",
+          needsClarification: true,
+          needsConfirmation: false,
+          readyToApply: false,
+          target: {
+            section: "coreSkills",
+            itemId: null,
+            field: null,
+            scope: "section",
+          },
+          draft: null,
+          warnings: [],
+        })
+        return
+      }
+
+      expect(payload.message).toBe("Yes create")
+      expect(payload.activeDraft).toBeUndefined()
+      expect(payload.conversation).toEqual([
+        { role: "user", text: "Add something in Core skills for Testing." },
+        { role: "assistant", text: "I do not see a Testing core skill group yet." },
+      ])
+      expect(payload.conversationContext).toBeUndefined()
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "grounded_suggestion",
+        reply: "What skills should I include in the new Testing core skill group?",
+        status: "blocked",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: false,
+        readyToApply: false,
+        target: {
+          section: "coreSkills",
+          itemId: null,
+          field: null,
+          scope: "section",
+        },
+        draft: null,
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await openChatAssistant(page)
+
+    await page.getByRole("textbox", { name: "Message" }).fill("Add something in Core skills for Testing.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await expect(page.getByText("I do not see a Testing core skill group yet. Do you want to create a new Testing group, or add the skill under an existing group like Database or Tools?")).toBeVisible()
+
+    await page.reload()
+    await openChatAssistant(page)
+    await expect(page.getByText("I do not see a Testing core skill group yet. Do you want to create a new Testing group, or add the skill under an existing group like Database or Tools?")).toBeVisible()
+    await expect(page.getByRole("textbox", { name: "Message" })).toHaveAttribute("placeholder", "Answer the assistant's question to continue.")
+
+    await page.getByRole("textbox", { name: "Message" }).fill("Yes create")
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    await expect(page.getByText("What skills should I include in the new Testing core skill group?")).toBeVisible()
+    expect(requestCount).toBe(2)
+  })
+
+  test("accept shows an inline error when the local draft cannot be applied safely", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    let requestCount = 0
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON()
+      expect(payload.activeDraft).toBeUndefined()
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "exact_edit",
+        reply: "I drafted a stronger summary for review.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "personalDetails",
+          itemId: null,
+          field: "summary",
+          scope: "resume_wide",
+        },
+        draft: {
+          summary: "A clearer summary draft is ready.",
+          proposedChanges: [
+            {
+              section: "personalDetails",
+              itemId: null,
+              field: "unsupportedField",
+              instruction: "Replace the unsupported field with the reviewed draft.",
+              proposedText: "Product-minded frontend developer building polished resume tools.",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await openChatAssistant(page)
+
+    await page.getByRole("textbox", { name: "Message" }).fill("Improve my summary.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await page.getByRole("button", { name: "Accept" }).click()
+
+    await expect(page.getByTestId("chat-inline-error")).toContainText("unsupported field")
+    await expect(page.getByText("Done. I applied that update to your resume. What would you like to improve next?")).toHaveCount(0)
+    expect(requestCount).toBe(1)
+  })
+
+  test("bulletSummary draft previews show only the new bullet instead of raw serialized arrays", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "exact_edit",
+        reply: "I drafted an extra Kaizer bullet for review.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "personalProjects",
+          itemId: "kaizer-project",
+          field: "bulletSummary",
+          scope: "single_item",
+        },
+        draft: {
+          summary: "Add Codex usage bullet to Kaizer project.",
+          proposedChanges: [
+            {
+              section: "personalProjects",
+              itemId: "kaizer-project",
+              field: "bulletSummary",
+              instruction: "Add the new Codex-related bullet to Kaizer.",
+              proposedText: "[\"Built a cross-platform desktop music player integrating multi-provider search, streaming, downloads, and local persistence.\",\"Implemented Electron IPC workflows, SQLite-backed state management, and fallback logic for offline playback and provider reliability.\",\"Used Codex to support development, debugging, and iteration during Kaizer's build.\"]",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await openChatAssistant(page)
+
+    await page.getByRole("textbox", { name: "Message" }).fill("Add a Codex bullet to Kaizer.")
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    const reviewCard = page.getByText("Add Codex usage bullet to Kaizer project.").locator("..")
+
+    await expect(page.getByText("Used Codex to support development, debugging, and iteration during Kaizer's build.")).toBeVisible()
+    await expect(reviewCard.getByTestId("chat-draft-breadcrumbs")).toContainText("Personal projects")
+    await expect(reviewCard.getByTestId("chat-draft-breadcrumbs")).toContainText("Bullet points")
+    await expect(reviewCard).not.toContainText("Updating:")
+    await expect(reviewCard).not.toContainText("personalProjects")
+    await expect(reviewCard).not.toContainText("bulletSummary")
+    await expect(reviewCard).not.toContainText("[\"Built a cross-platform desktop music player")
+  })
+
+  test("coreSkills draft previews show a readable group and skills instead of raw JSON", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "exact_edit",
+        reply: "I drafted a new core skill group for review.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "coreSkills",
+          itemId: null,
+          field: null,
+          scope: "section",
+        },
+        draft: {
+          summary: "Create a new Testing core skill group.",
+          proposedChanges: [
+            {
+              section: "coreSkills",
+              itemId: null,
+              field: null,
+              instruction: "Create the Testing core skill group with the provided tools.",
+              proposedText: "{\"devLanguage\":\"Testing\",\"devFramework\":[\"Jest\",\"Playwright\"]}",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await openChatAssistant(page)
+
+    await page.getByRole("textbox", { name: "Message" }).fill("Create a Testing core skill group.")
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    const reviewCard = page.getByText("Create a new Testing core skill group.").locator("..")
+
+    await expect(reviewCard).toContainText("New group")
+    await expect(reviewCard).toContainText("Testing")
+    await expect(reviewCard).toContainText("Skills")
+    await expect(reviewCard).toContainText("Jest, Playwright")
+    await expect(reviewCard).not.toContainText("New group:")
+    await expect(reviewCard).not.toContainText("Skills:")
+    await expect(reviewCard.getByTestId("chat-draft-breadcrumbs")).toContainText("Core skills")
+    await expect(reviewCard).not.toContainText("Updating:")
+    await expect(reviewCard).not.toContainText("{\"devLanguage\":\"Testing\",\"devFramework\":[\"Jest\",\"Playwright\"]}")
+    await expect(reviewCard).not.toContainText("devLanguage")
+    await expect(reviewCard).not.toContainText("devFramework")
+    await expect(page.getByRole("button", { name: "Accept" })).toBeVisible()
+    await expect(page.getByRole("button", { name: "Reject" })).toBeVisible()
+  })
+
+  test("multi-item coreSkills create drafts render every returned group, not just the first one", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "grounded_suggestion",
+        reply: "I drafted four new core skill groups for review.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "coreSkills",
+          itemId: null,
+          field: null,
+          scope: "section",
+        },
+        draft: {
+          summary: "Create four new core skill items for development specialties.",
+          proposedChanges: [
+            {
+              section: "coreSkills",
+              itemId: null,
+              field: null,
+              instruction: "Add a new core skill item named Frontend with common frontend frameworks.",
+              proposedText: "{\"devLanguage\":\"Frontend\",\"devFramework\":[\"React\",\"Vue\",\"Angular\"]}",
+            },
+            {
+              section: "coreSkills",
+              itemId: null,
+              field: null,
+              instruction: "Add a new core skill item named Backend with common backend frameworks.",
+              proposedText: "{\"devLanguage\":\"Backend\",\"devFramework\":[\"Node.js\",\"Express\",\"Django\"]}",
+            },
+            {
+              section: "coreSkills",
+              itemId: null,
+              field: null,
+              instruction: "Add a new core skill item named Testing with common testing tools.",
+              proposedText: "{\"devLanguage\":\"Testing\",\"devFramework\":[\"Jest\",\"Playwright\",\"Mocha\"]}",
+            },
+            {
+              section: "coreSkills",
+              itemId: null,
+              field: null,
+              instruction: "Add a new core skill item named Database with common database technologies.",
+              proposedText: "{\"devLanguage\":\"Database\",\"devFramework\":[\"PostgreSQL\",\"MySQL\",\"MongoDB\"]}",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await openChatAssistant(page)
+
+    await page.getByRole("textbox", { name: "Message" }).fill("Create four new core skill groups.")
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    const reviewCard = page.getByTestId("chat-draft-review")
+    await expect(reviewCard).toContainText("New group")
+    await expect(reviewCard).toContainText("Frontend")
+    await expect(reviewCard).toContainText("React, Vue, Angular")
+    await expect(reviewCard).toContainText("Backend")
+    await expect(reviewCard).toContainText("Node.js, Express, Django")
+    await expect(reviewCard).toContainText("Testing")
+    await expect(reviewCard).toContainText("Jest, Playwright, Mocha")
+    await expect(reviewCard).toContainText("Database")
+    await expect(reviewCard).toContainText("PostgreSQL, MySQL, MongoDB")
+    await expect(reviewCard).not.toContainText("New group:")
+    await expect(reviewCard).not.toContainText("Skills:")
+    await expect(reviewCard).not.toContainText("{\"devLanguage\":\"Frontend\"")
+    await expect(page.getByRole("button", { name: "Accept" })).toHaveCount(1)
+    await expect(page.getByRole("button", { name: "Reject" })).toHaveCount(1)
+  })
+
+  test("coreSkills update drafts show each existing group and proposed frameworks", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    let requestCount = 0
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON()
+      expect(payload.activeDraft).toBeUndefined()
+      expect(Array.isArray(payload.resumeData.coreSkills)).toBe(true)
+
+      const coreSkills = payload.resumeData.coreSkills as Array<{ id: string; devLanguage: string }>
+      const frontend = coreSkills.find((item) => item.devLanguage === "Frontend")
+      const backend = coreSkills.find((item) => item.devLanguage === "Backend")
+      const tools = coreSkills.find((item) => item.devLanguage === "Tools")
+
+      expect(frontend?.id).toBeTruthy()
+      expect(backend?.id).toBeTruthy()
+      expect(tools?.id).toBeTruthy()
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "grounded_suggestion",
+        reply: "Draft ready to update your Core Skills.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "coreSkills",
+          itemId: frontend?.id ?? null,
+          field: "devFramework",
+          scope: "section",
+        },
+        draft: {
+          summary: "Update Core Skills framework lists across Frontend, Backend and Tools.",
+          proposedChanges: [
+            {
+              section: "coreSkills",
+              itemId: frontend?.id ?? null,
+              field: "devFramework",
+              instruction: "Replace frontend frameworks with the reviewed list.",
+              proposedText: "[\"React\",\"Next.js\",\"Tailwind CSS\"]",
+            },
+            {
+              section: "coreSkills",
+              itemId: backend?.id ?? null,
+              field: "devFramework",
+              instruction: "Replace backend frameworks with the reviewed list.",
+              proposedText: "[\"Node.js\",\"Express\",\"PostgreSQL\"]",
+            },
+            {
+              section: "coreSkills",
+              itemId: tools?.id ?? null,
+              field: "devFramework",
+              instruction: "Replace tools with the reviewed list.",
+              proposedText: "[\"Git\",\"Docker\",\"Vite\"]",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await page.getByRole("button", { name: "Skill" }).click()
+
+    for (const groupName of ["Frontend", "Backend", "Tools"]) {
+      await page.getByRole("button", { name: "Add an item" }).click()
+      await page.getByLabel("Language").fill(groupName)
+      await page.keyboard.press(",")
+      await expect(page.getByRole("button", { name: groupName })).toBeVisible()
+    }
+
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill("I want to update my core skills.")
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    const reviewCard = page.getByText("Update Core Skills framework lists across Frontend, Backend and Tools.").locator("..")
+    await expect(reviewCard.getByTestId("chat-draft-breadcrumbs").filter({ hasText: "Frontend" })).toContainText("Skills")
+    await expect(reviewCard).not.toContainText("Updating:")
+    await expect(reviewCard).toContainText("Frontend")
+    await expect(reviewCard).toContainText("React, Next.js, Tailwind CSS")
+    await expect(reviewCard).toContainText("Backend")
+    await expect(reviewCard).toContainText("Node.js, Express, PostgreSQL")
+    await expect(reviewCard).toContainText("Tools")
+    await expect(reviewCard).toContainText("Git, Docker, Vite")
+    await expect(reviewCard).not.toContainText("[\"React\"")
+    await expect(reviewCard).not.toContainText("devFramework")
+
+    await page.getByRole("button", { name: "Accept" }).click()
+    await expect(page.getByText("Done. I applied that update to your resume. What would you like to improve next?")).toBeVisible()
+
+    await page.keyboard.press("Escape")
+    await expect(page.getByRole("button", { name: /Frontend\s+React, Next\.js, Tailwind CSS/ })).toBeVisible()
+    await expect(page.getByRole("button", { name: /Backend\s+Node\.js, Express, PostgreSQL/ })).toBeVisible()
+    await expect(page.getByRole("button", { name: /Tools\s+Git, Docker, Vite/ })).toBeVisible()
+    expect(requestCount).toBe(1)
+  })
+
+  test("structured create-item drafts render friendly field previews instead of raw JSON", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    const draftResponses = [
+      {
+        message: "Please draft a starter project item.",
+        reply: "I drafted a starter project item for review.",
+        section: "personalProjects",
+        summary: "Create a starter project item.",
+        proposedText: JSON.stringify({
+          projectName: "",
+          projectSubtitle: "",
+          preview: "",
+          briefSummary: "",
+          bulletType: false,
+          bulletSummary: [],
+        }),
+        expectedRows: [
+          "Project name",
+          "Project subtitle",
+          "Project link",
+          "Description",
+          "Use bullet points",
+          "Bullet points",
+          "Not set yet",
+          "No",
+          "None yet",
+        ],
+        rawText: "{\"projectName\"",
+        rawKey: "projectName",
+      },
+      {
+        message: "Please draft a starter work experience.",
+        reply: "I drafted a starter work experience for review.",
+        section: "workExperiences",
+        summary: "Create a starter work experience.",
+        proposedText: JSON.stringify({
+          companyName: "",
+          jobTitle: "",
+          briefSummary: "",
+          startYear: "",
+          endYear: "",
+          currentlyHired: false,
+          bulletType: false,
+          bulletSummary: [],
+        }),
+        expectedRows: [
+          "Company name",
+          "Job title",
+          "Description",
+          "Start date",
+          "End date",
+          "Currently employed",
+          "Use bullet points",
+          "Bullet points",
+          "Not set yet",
+          "No",
+          "None yet",
+        ],
+        rawText: "{\"companyName\"",
+        rawKey: "companyName",
+      },
+      {
+        message: "Please draft a starter certificate.",
+        reply: "I drafted a starter certificate for review.",
+        section: "certificates",
+        summary: "Create a starter certificate.",
+        proposedText: JSON.stringify({
+          certificateName: "",
+          certificateIssuer: "",
+          yearIssued: "",
+          certificateDescription: "",
+        }),
+        expectedRows: [
+          "Certificate title",
+          "Issuer",
+          "Year issued",
+          "Certificate description",
+          "Not set yet",
+        ],
+        rawText: "{\"certificateName\"",
+        rawKey: "certificateName",
+      },
+      {
+        message: "Please draft a starter achievement.",
+        reply: "I drafted a starter achievement for review.",
+        section: "achievements",
+        summary: "Create a starter achievement.",
+        proposedText: JSON.stringify({
+          achievementName: "",
+          achievementIssuer: "",
+          yearIssued: "",
+          achievementDescription: "",
+        }),
+        expectedRows: [
+          "Achievement title",
+          "Issuer",
+          "Year issued",
+          "Achievement description",
+          "Not set yet",
+        ],
+        rawText: "{\"achievementName\"",
+        rawKey: "achievementName",
+      },
+    ] as const
+    let requestCount = 0
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      const draftResponse = draftResponses[requestCount]
+      requestCount += 1
+      const payload = route.request().postDataJSON()
+
+      expect(payload.message).toBe(draftResponse.message)
+      expect(payload.activeDraft).toBeUndefined()
+      expect(payload.conversationContext).toBeUndefined()
+      expect(payload.debugProvider).toBeUndefined()
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "grounded_suggestion",
+        reply: draftResponse.reply,
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: draftResponse.section,
+          itemId: null,
+          field: null,
+          scope: "section",
+        },
+        draft: {
+          summary: draftResponse.summary,
+          proposedChanges: [
+            {
+              section: draftResponse.section,
+              itemId: null,
+              field: null,
+              instruction: "Create a new item from the reviewed structured draft.",
+              proposedText: draftResponse.proposedText,
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await openChatAssistant(page)
+
+    for (const draftResponse of draftResponses) {
+      await page.getByRole("textbox", { name: "Message" }).fill(draftResponse.message)
+      await page.getByRole("button", { name: "Send message" }).click()
+
+      const reviewCard = page.getByText(draftResponse.summary).locator("..")
+      for (const row of draftResponse.expectedRows) {
+        await expect(reviewCard).toContainText(row)
+      }
+      await expect(reviewCard).not.toContainText(draftResponse.rawText)
+      await expect(reviewCard).not.toContainText(draftResponse.rawKey)
+      await expect(page.getByRole("button", { name: "Accept" })).toBeVisible()
+      await expect(page.getByRole("button", { name: "Reject" })).toBeVisible()
+
+      await page.getByRole("button", { name: "Reject" }).click()
+    }
+
+    expect(requestCount).toBe(draftResponses.length)
+  })
+
+  test("multi-item structured create drafts render one friendly preview block per proposed change", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "grounded_suggestion",
+        reply: "I drafted two certificate items for review.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "certificates",
+          itemId: null,
+          field: null,
+          scope: "section",
+        },
+        draft: {
+          summary: "Create two certificate items.",
+          proposedChanges: [
+            {
+              section: "certificates",
+              itemId: null,
+              field: null,
+              instruction: "Create the AWS certificate item.",
+              proposedText:
+                "{\"certificateName\":\"AWS Cloud Practitioner\",\"certificateIssuer\":\"Amazon Web Services\",\"yearIssued\":\"2024\",\"certificateDescription\":\"Foundational cloud certification.\"}",
+            },
+            {
+              section: "certificates",
+              itemId: null,
+              field: null,
+              instruction: "Create the Google certificate item.",
+              proposedText:
+                "{\"certificateName\":\"Google UX Design\",\"certificateIssuer\":\"Google\",\"yearIssued\":\"2023\",\"certificateDescription\":\"User experience design coursework.\"}",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await openChatAssistant(page)
+
+    await page.getByRole("textbox", { name: "Message" }).fill("Draft two certificates.")
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    const reviewCard = page.getByTestId("chat-draft-review")
+    await expect(reviewCard).toContainText("Certificate title")
+    await expect(reviewCard).toContainText("AWS Cloud Practitioner")
+    await expect(reviewCard).toContainText("Issuer")
+    await expect(reviewCard).toContainText("Amazon Web Services")
+    await expect(reviewCard).toContainText("Year issued")
+    await expect(reviewCard).toContainText("2024")
+    await expect(reviewCard).toContainText("Certificate description")
+    await expect(reviewCard).toContainText("Foundational cloud certification.")
+    await expect(reviewCard).toContainText("Google UX Design")
+    await expect(reviewCard).toContainText("Google")
+    await expect(reviewCard).toContainText("2023")
+    await expect(reviewCard).toContainText("User experience design coursework.")
+    await expect(reviewCard).not.toContainText("Certificate title:")
+    await expect(reviewCard).not.toContainText("{\"certificateName\":\"AWS Cloud Practitioner\"")
+    await expect(page.getByRole("button", { name: "Accept" })).toHaveCount(1)
+    await expect(page.getByRole("button", { name: "Reject" })).toHaveCount(1)
+
+    await page.getByRole("button", { name: "Reject" }).click()
+  })
+
+  test("multi-item plain-text field drafts render every proposed text entry", async ({ page }) => {
+    let kaizerId = ""
+    let novaId = ""
+
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      const payload = route.request().postDataJSON()
+
+      kaizerId = payload.resumeData.personalProjects.find((item: { projectName: string }) => item.projectName === "Kaizer")?.id ?? ""
+      novaId = payload.resumeData.personalProjects.find((item: { projectName: string }) => item.projectName === "Nova")?.id ?? ""
+
+      expect(kaizerId).toBeTruthy()
+      expect(novaId).toBeTruthy()
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "exact_edit",
+        reply: "I drafted clearer descriptions for both projects.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "personalProjects",
+          itemId: kaizerId,
+          field: "briefSummary",
+          scope: "section",
+        },
+        draft: {
+          summary: "Refresh both project descriptions.",
+          proposedChanges: [
+            {
+              section: "personalProjects",
+              itemId: kaizerId,
+              field: "briefSummary",
+              instruction: "Rewrite the Kaizer description.",
+              proposedText: "Desktop music platform focused on multi-provider playback and offline reliability.",
+            },
+            {
+              section: "personalProjects",
+              itemId: novaId,
+              field: "briefSummary",
+              instruction: "Rewrite the Nova description.",
+              proposedText: "Clean weather experience built around responsive forecasts and practical daily planning.",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await page.getByRole("button", { name: "Personal Project" }).click()
+
+    await page.getByRole("button", { name: "Add an item" }).click()
+    await page.getByLabel("Project name").fill("Kaizer")
+
+    await page.getByRole("button", { name: "Add an item" }).click()
+    await page.getByLabel("Project name").last().fill("Nova")
+
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill("Refresh both project descriptions.")
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    const reviewCard = page.getByTestId("chat-draft-review")
+    await expect(reviewCard.getByTestId("chat-draft-breadcrumbs").filter({ hasText: "Kaizer" })).toContainText("Description")
+    await expect(reviewCard).toContainText("Desktop music platform focused on multi-provider playback and offline reliability.")
+    await expect(reviewCard.getByTestId("chat-draft-breadcrumbs").filter({ hasText: "Nova" })).toContainText("Description")
+    await expect(reviewCard).toContainText("Clean weather experience built around responsive forecasts and practical daily planning.")
+    await expect(reviewCard).not.toContainText("Updating:")
+    await expect(page.getByRole("button", { name: "Accept" })).toHaveCount(1)
+    await expect(page.getByRole("button", { name: "Reject" })).toHaveCount(1)
+  })
+
+  test("accept applies a personalProjects create draft by adding a new local project item", async ({ page }) => {
+    let requestCount = 0
+
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON()
+
+      expect(payload.message).toBe("I want to add a new project.")
+      expect(payload.activeDraft).toBeUndefined()
+      expect(payload.conversation).toBeUndefined()
+      expect(payload.conversationContext).toBeUndefined()
+      expect(payload.debugProvider).toBeUndefined()
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "grounded_suggestion",
+        reply: "Draft ready to add a new Personal Project item with the provided details.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "personalProjects",
+          itemId: null,
+          field: null,
+          scope: "section",
+        },
+        draft: {
+          summary: "Create a new Personal Project item with the provided details.",
+          proposedChanges: [
+            {
+              section: "personalProjects",
+              itemId: null,
+              field: null,
+              instruction: "Add a new personal project item with the full item shape (projectName, projectSubtitle, preview, briefSummary, bulletSummary, bulletType).",
+              proposedText:
+                "{\"projectName\":\"Codex Skill\",\"projectSubtitle\":\"Agent skill\",\"preview\":\"No link\",\"briefSummary\":\"This project would help the user have coding agents to give best practices.\",\"bulletType\":false,\"bulletSummary\":[]}",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await page.getByRole("button", { name: "Personal Project" }).click()
+    await expect(page.getByText("Untitled project")).toHaveCount(0)
+
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill("I want to add a new project.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await expect(page.getByRole("button", { name: "Accept" })).toBeVisible()
+
+    await page.getByRole("button", { name: "Accept" }).click()
+
+    await expect(page.getByText("Done. I applied that update to your resume. What would you like to improve next?")).toBeVisible()
+    await expect(page.getByRole("button", { name: "Accept" })).toHaveCount(0)
+    await expect(page.getByRole("button", { name: "Reject" })).toHaveCount(0)
+    await expect(page.getByTestId("chat-inline-error")).toHaveCount(0)
+
+    await page.keyboard.press("Escape")
+    await expect(page.getByRole("button", { name: "Codex Skill Agent skill" })).toBeVisible()
+    await expect(page.getByLabel("Project name")).toHaveValue("Codex Skill")
+    await expect(page.getByLabel("Project subtitle")).toHaveValue("Agent skill")
+    await expect(page.getByLabel("Preview link (optional)")).toHaveValue("No link")
+    await expect(page.getByLabel("Brief summary")).toHaveValue(
+      "This project would help the user have coding agents to give best practices.",
+    )
+    await expect(page.getByLabel("Use bullet points")).not.toBeChecked()
+    expect(requestCount).toBe(1)
+  })
+
+  test("accept applies a workExperiences create draft by adding a new local work item", async ({ page }) => {
+    let requestCount = 0
+
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON()
+
+      expect(payload.message).toBe("I want to add my experience.")
+      expect(payload.activeDraft).toBeUndefined()
+      expect(payload.conversation).toBeUndefined()
+      expect(payload.conversationContext).toBeUndefined()
+      expect(payload.debugProvider).toBeUndefined()
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "exact_edit",
+        reply: "Draft ready to update the bullets for the TerniLabs Software Engineer entry starting November 2025.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "workExperiences",
+          itemId: null,
+          field: null,
+          scope: "section",
+        },
+        draft: {
+          summary: "Update bullets for TerniLabs Software Engineer entry starting November 2025.",
+          proposedChanges: [
+            {
+              section: "workExperiences",
+              itemId: null,
+              field: null,
+              instruction: "Replace the existing bulletSummary items with improved, achievement-focused bullets.",
+              proposedText:
+                "{\"companyName\":\"TerniLabs\",\"jobTitle\":\"Software Engineer\",\"briefSummary\":\"\",\"startYear\":\"November 2025\",\"endYear\":\"present\",\"currentlyHired\":true,\"bulletType\":false,\"bulletSummary\":[\"Developed AI-powered software components.\",\"Built responsive web applications to improve user experience and accessibility.\",\"Collaborated with cross-functional teams to enable data-driven decision making and accelerate delivery\"]}",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await page.getByRole("button", { name: "Work Experience" }).click()
+    await expect(page.getByText("Untitled work experience")).toHaveCount(0)
+
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill("I want to add my experience.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await expect(page.getByRole("button", { name: "Accept" })).toBeVisible()
+
+    await page.getByRole("button", { name: "Accept" }).click()
+
+    await expect(page.getByText("Done. I applied that update to your resume. What would you like to improve next?")).toBeVisible()
+    await expect(page.getByRole("button", { name: "Accept" })).toHaveCount(0)
+    await expect(page.getByRole("button", { name: "Reject" })).toHaveCount(0)
+    await expect(page.getByTestId("chat-inline-error")).toHaveCount(0)
+
+    await page.keyboard.press("Escape")
+    await expect(page.getByRole("button", { name: "Software Engineer TerniLabs" })).toBeVisible()
+    await expect(page.getByLabel("Position")).toHaveValue("Software Engineer")
+    await expect(page.getByLabel("Company")).toHaveValue("TerniLabs")
+    await expect(page.getByLabel("Year started")).toHaveValue("November 2025")
+    await expect(page.getByLabel("Present")).toBeChecked()
+    await expect(page.getByLabel("Use bullet points")).not.toBeChecked()
+    expect(requestCount).toBe(1)
+  })
+
+  test("accept applies a certificates create draft by adding a new local certificate item", async ({ page }) => {
+    let requestCount = 0
+
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON()
+
+      expect(payload.message).toBe("I want to add a certificate.")
+      expect(payload.activeDraft).toBeUndefined()
+      expect(payload.conversation).toBeUndefined()
+      expect(payload.conversationContext).toBeUndefined()
+      expect(payload.debugProvider).toBeUndefined()
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "grounded_suggestion",
+        reply: "Draft ready to add a new certificate item with the provided details.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "certificates",
+          itemId: null,
+          field: null,
+          scope: "section",
+        },
+        draft: {
+          summary: "Create a new certificate item with the provided details.",
+          proposedChanges: [
+            {
+              section: "certificates",
+              itemId: null,
+              field: null,
+              instruction: "Add a new certificate item with the provided details.",
+              proposedText:
+                "{\"certificateName\":\"Responsive Web Design\",\"certificateIssuer\":\"freeCodeCamp\",\"yearIssued\":\"September 2025\",\"certificateDescription\":\"Completed coursework in HTML and CSS\"}",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await page.getByRole("button", { name: "Certificate" }).click()
+
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill("I want to add a certificate.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await expect(page.getByRole("button", { name: "Accept" })).toBeVisible()
+
+    await page.getByRole("button", { name: "Accept" }).click()
+
+    await expect(page.getByText("Done. I applied that update to your resume. What would you like to improve next?")).toBeVisible()
+    await expect(page.getByRole("button", { name: "Accept" })).toHaveCount(0)
+    await expect(page.getByRole("button", { name: "Reject" })).toHaveCount(0)
+    await expect(page.getByTestId("chat-inline-error")).toHaveCount(0)
+
+    await page.keyboard.press("Escape")
+    await expect(page.getByRole("button", { name: "Responsive Web Design freeCodeCamp" })).toBeVisible()
+    await expect(page.getByLabel("Name")).toHaveValue("Responsive Web Design")
+    await expect(page.getByLabel("Institution")).toHaveValue("freeCodeCamp")
+    await expect(page.getByLabel("Year issued")).toHaveValue("September 2025")
+    await expect(page.getByLabel("Description")).toHaveValue("Completed coursework in HTML and CSS")
+    expect(requestCount).toBe(1)
+  })
+
+  test("certificate drafts with escaped JSON and numeric year preview cleanly and apply locally", async ({ page }) => {
+    let requestCount = 0
+
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON()
+
+      expect(payload.message).toBe("Add my CS50x certificate.")
+      expect(payload.activeDraft).toBeUndefined()
+      expect(payload.conversationContext).toBeUndefined()
+      expect(payload.debugProvider).toBeUndefined()
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "grounded_suggestion",
+        reply: "Draft ready to add a new certificate entry for CS50x: Introduction to Computer Science.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "certificates",
+          itemId: null,
+          field: null,
+          scope: "section",
+        },
+        draft: {
+          summary: "Create a new certificate item for CS50x: Introduction to Computer Science.",
+          proposedChanges: [
+            {
+              section: "certificates",
+              itemId: null,
+              field: null,
+              instruction: "Add a new certificate item with the provided details.",
+              proposedText:
+                "{\\\"certificateName\\\":\\\"CS50x: Introduction to Computer Science\\\",\\\"certificateIssuer\\\":\\\"HarvardX\\\",\\\"yearIssued\\\":2025,\\\"certificateDescription\\\":\\\"Completed CS50x: Introduction to Computer Science coursework (HarvardX) in January 2025.\\\"}",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill("Add my CS50x certificate.")
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    const reviewCard = page.getByTestId("chat-draft-review")
+    await expect(reviewCard).toContainText("Certificate title")
+    await expect(reviewCard).toContainText("CS50x: Introduction to Computer Science")
+    await expect(reviewCard).toContainText("Issuer")
+    await expect(reviewCard).toContainText("HarvardX")
+    await expect(reviewCard).toContainText("Year issued")
+    await expect(reviewCard).toContainText("2025")
+    await expect(reviewCard).toContainText("Certificate description")
+    await expect(reviewCard).toContainText("Completed CS50x: Introduction to Computer Science coursework (HarvardX) in January 2025.")
+    await expect(reviewCard.getByTestId("chat-draft-breadcrumbs")).toContainText("Certificates")
+    await expect(reviewCard).not.toContainText("Updating:")
+    await expect(reviewCard).not.toContainText("Certificate title:")
+    await expect(reviewCard).not.toContainText("{\"certificateName\"")
+    await expect(reviewCard).not.toContainText("certificateIssuer")
+
+    await page.getByRole("button", { name: "Accept" }).click()
+    await expect(page.getByText("Done. I applied that update to your resume. What would you like to improve next?")).toBeVisible()
+    await expect(page.getByTestId("chat-inline-error")).toHaveCount(0)
+
+    await page.keyboard.press("Escape")
+    await expect(page.getByRole("button", { name: "Certificate" })).toBeVisible()
+    await page.getByRole("button", { name: "Certificate" }).click()
+    await expect(page.getByRole("button", { name: "CS50x: Introduction to Computer Science HarvardX" })).toBeVisible()
+    await expect(page.getByLabel("Name")).toHaveValue("CS50x: Introduction to Computer Science")
+    await expect(page.getByLabel("Institution")).toHaveValue("HarvardX")
+    await expect(page.getByLabel("Year issued")).toHaveValue("2025")
+    await expect(page.getByLabel("Description")).toHaveValue("Completed CS50x: Introduction to Computer Science coursework (HarvardX) in January 2025.")
+    expect(requestCount).toBe(1)
+  })
+
+  test("accept applies an achievements create draft by adding a new local achievement item", async ({ page }) => {
+    let requestCount = 0
+
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON()
+
+      expect(payload.message).toBe("I want to add an achievement.")
+      expect(payload.activeDraft).toBeUndefined()
+      expect(payload.conversation).toBeUndefined()
+      expect(payload.conversationContext).toBeUndefined()
+      expect(payload.debugProvider).toBeUndefined()
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "grounded_suggestion",
+        reply: "Draft ready to add a new achievement item with the provided details.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "achievements",
+          itemId: null,
+          field: null,
+          scope: "section",
+        },
+        draft: {
+          summary: "Create a new achievement item with the provided details.",
+          proposedChanges: [
+            {
+              section: "achievements",
+              itemId: null,
+              field: null,
+              instruction: "Add a new achievement item with the provided details.",
+              proposedText:
+                "{\"achievementName\":\"Academic Excellence Award\",\"achievementIssuer\":\"Maritime Studies\",\"yearIssued\":\"October 2021\",\"achievementDescription\":\"Recognized for outstanding scholastic performance.\"}",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await page.getByRole("button", { name: "Achievement" }).click()
+
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill("I want to add an achievement.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await expect(page.getByRole("button", { name: "Accept" })).toBeVisible()
+
+    await page.getByRole("button", { name: "Accept" }).click()
+
+    await expect(page.getByText("Done. I applied that update to your resume. What would you like to improve next?")).toBeVisible()
+    await expect(page.getByRole("button", { name: "Accept" })).toHaveCount(0)
+    await expect(page.getByRole("button", { name: "Reject" })).toHaveCount(0)
+    await expect(page.getByTestId("chat-inline-error")).toHaveCount(0)
+
+    await page.keyboard.press("Escape")
+    await expect(page.getByRole("button", { name: "Academic Excellence Award Maritime Studies" })).toBeVisible()
+    await expect(page.getByLabel("Name")).toHaveValue("Academic Excellence Award")
+    await expect(page.getByLabel("Institution")).toHaveValue("Maritime Studies")
+    await expect(page.getByLabel("Year issued")).toHaveValue("October 2021")
+    await expect(page.getByLabel("Description")).toHaveValue("Recognized for outstanding scholastic performance.")
+    expect(requestCount).toBe(1)
+  })
+
+  test("accept applies section-clear drafts by deleting every item in an array-backed section", async ({ page }) => {
+    let requestCount = 0
+
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON()
+
+      expect(payload.message).toBe("I want to remove everything in Certificates.")
+      expect(payload.activeDraft).toBeUndefined()
+      expect(payload.conversation).toBeUndefined()
+      expect(payload.conversationContext).toBeUndefined()
+      expect(payload.debugProvider).toBeUndefined()
+      expect(payload.resumeData.certificates).toHaveLength(2)
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "exact_edit",
+        reply: "Draft ready to clear the Certificates section.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "certificates",
+          itemId: null,
+          field: null,
+          scope: "section",
+        },
+        draft: {
+          summary: "Clear all items in Certificates.",
+          proposedChanges: [
+            {
+              section: "certificates",
+              itemId: null,
+              field: null,
+              instruction: "Remove all certificate entries from the Certificates section.",
+              proposedText: "[]",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await page.getByRole("button", { name: "Certificate" }).click()
+    await page.getByRole("button", { name: "Add an item" }).click()
+    await page.getByLabel("Name").fill("Responsive Web Design")
+    await page.getByLabel("Institution").fill("freeCodeCamp")
+
+    await page.getByRole("button", { name: "Add an item" }).click()
+    await page.getByLabel("Name").last().fill("JavaScript Algorithms")
+    await page.getByLabel("Institution").last().fill("freeCodeCamp")
+
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill("I want to remove everything in Certificates.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await expect(page.getByRole("button", { name: "Accept" })).toBeVisible()
+
+    await page.getByRole("button", { name: "Accept" }).click()
+
+    await expect(page.getByText("Done. I applied that update to your resume. What would you like to improve next?")).toBeVisible()
+    await expect(page.getByRole("button", { name: "Accept" })).toHaveCount(0)
+    await expect(page.getByRole("button", { name: "Reject" })).toHaveCount(0)
+    await expect(page.getByTestId("chat-inline-error")).toHaveCount(0)
+
+    await page.keyboard.press("Escape")
+    await expect(page.getByRole("button", { name: "Responsive Web Design freeCodeCamp" })).toHaveCount(0)
+    await expect(page.getByRole("button", { name: "JavaScript Algorithms freeCodeCamp" })).toHaveCount(0)
+    expect(requestCount).toBe(1)
+  })
+
+  test("accept applies section-clear drafts when the empty-list payload is double-encoded", async ({ page }) => {
+    let requestCount = 0
+
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "exact_edit",
+        reply: "Draft ready to clear the Achievements section.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "achievements",
+          itemId: null,
+          field: null,
+          scope: "section",
+        },
+        draft: {
+          summary: "Clear all items in Achievements.",
+          proposedChanges: [
+            {
+              section: "achievements",
+              itemId: null,
+              field: null,
+              instruction: "Remove all achievement entries from the Achievements section.",
+              proposedText: "\"[]\"",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await page.getByRole("button", { name: "Achievement" }).click()
+    await page.getByRole("button", { name: "Add an item" }).click()
+    await page.getByLabel("Name").fill("Academic Excellence")
+    await page.getByLabel("Institution").fill("Harvard")
+
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill("I want to remove everything in Achievements.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await expect(page.getByRole("button", { name: "Accept" })).toBeVisible()
+
+    await page.getByRole("button", { name: "Accept" }).click()
+
+    await expect(page.getByText("Done. I applied that update to your resume. What would you like to improve next?")).toBeVisible()
+    await expect(page.getByTestId("chat-inline-error")).toHaveCount(0)
+
+    await page.keyboard.press("Escape")
+    await expect(page.getByRole("button", { name: "Academic Excellence Harvard" })).toHaveCount(0)
+    expect(requestCount).toBe(1)
+  })
+
+  test("accept applies softSkills field-clear drafts by emptying the soft skills list", async ({ page }) => {
+    let requestCount = 0
+
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON()
+
+      expect(payload.message).toBe("Delete everything in soft skills.")
+      expect(payload.activeDraft).toBeUndefined()
+      expect(payload.conversation).toBeUndefined()
+      expect(payload.conversationContext).toBeUndefined()
+      expect(payload.debugProvider).toBeUndefined()
+      expect(payload.resumeData.softSkills).toEqual(["Communication", "Problem Solving"])
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "grounded_suggestion",
+        reply: "Draft ready to clear all soft skills.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "softSkills",
+          itemId: null,
+          field: "items",
+          scope: "section",
+        },
+        draft: {
+          summary: "Clear all soft skills from the résumé.",
+          proposedChanges: [
+            {
+              section: "softSkills",
+              itemId: null,
+              field: "items",
+              instruction: "Remove all items in softSkills.",
+              proposedText: "[]",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await page.getByRole("button", { name: "Skill" }).click()
+    const softSkillsField = page.locator("fieldset").filter({ hasText: "Soft skills" })
+    await page.getByRole("combobox", { name: "Soft skills" }).fill("Communication")
+    await page.keyboard.press(",")
+    await page.getByRole("combobox", { name: "Soft skills" }).fill("Problem Solving")
+    await page.keyboard.press(",")
+    await expect(softSkillsField).toContainText("Communication")
+    await expect(softSkillsField).toContainText("Problem solving")
+
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill("Delete everything in soft skills.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await expect(page.getByRole("button", { name: "Accept" })).toBeVisible()
+
+    await page.getByRole("button", { name: "Accept" }).click()
+
+    await expect(page.getByText("Done. I applied that update to your resume. What would you like to improve next?")).toBeVisible()
+    await expect(page.getByTestId("chat-inline-error")).toHaveCount(0)
+
+    await page.keyboard.press("Escape")
+    await expect(softSkillsField).not.toContainText("Communication")
+    await expect(softSkillsField).not.toContainText("Problem solving")
+    expect(requestCount).toBe(1)
+  })
+
+  test("softSkills JSON-array drafts preview cleanly and apply locally", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      const payload = route.request().postDataJSON()
+      expect(payload.activeDraft).toBeUndefined()
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "grounded_suggestion",
+        reply: "I drafted updated soft skills for review.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "softSkills",
+          itemId: null,
+          field: null,
+          scope: "section",
+        },
+        draft: {
+          summary: "Replace the soft skills list.",
+          proposedChanges: [
+            {
+              section: "softSkills",
+              itemId: null,
+              field: null,
+              instruction: "Replace soft skills with the reviewed list.",
+              proposedText: "[\"Problem Solving\",\"Communication\",\"problem solving\"]",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await page.getByRole("button", { name: "Skill" }).click()
+    await openChatAssistant(page)
+
+    await page.getByRole("textbox", { name: "Message" }).fill("Improve my soft skills.")
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    const reviewCard = page.getByText("Replace the soft skills list.").locator("..")
+    await expect(reviewCard).toContainText("Problem Solving")
+    await expect(reviewCard).toContainText("Communication")
+    await expect(reviewCard).not.toContainText("[\"Problem Solving\"")
+
+    await page.getByRole("button", { name: "Accept" }).click()
+    await expect(page.getByText("Done. I applied that update to your resume. What would you like to improve next?")).toBeVisible()
+
+    await page.keyboard.press("Escape")
+    await expect(page.getByText("Problem Solving")).toBeVisible()
+    await expect(page.getByText("Communication")).toBeVisible()
+    await expect(page.getByText("Problem Solving")).toHaveCount(1)
+  })
+
+  test("knownLanguages JSON-array drafts preview cleanly and apply locally", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      const payload = route.request().postDataJSON()
+      expect(payload.activeDraft).toBeUndefined()
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "grounded_suggestion",
+        reply: "I drafted updated languages for review.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "personalDetails",
+          itemId: null,
+          field: "knownLanguages",
+          scope: "resume_wide",
+        },
+        draft: {
+          summary: "Replace the languages list.",
+          proposedChanges: [
+            {
+              section: "personalDetails",
+              itemId: null,
+              field: "knownLanguages",
+              instruction: "Replace known languages with the reviewed list.",
+              proposedText: "[\"English\",\"Tagalog\"]",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await page.getByRole("button", { name: "About you" }).click()
+    await openChatAssistant(page)
+
+    await page.getByRole("textbox", { name: "Message" }).fill("Update my languages.")
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    const reviewCard = page.getByText("Replace the languages list.").locator("..")
+    await expect(reviewCard).toContainText("English")
+    await expect(reviewCard).toContainText("Tagalog")
+    await expect(reviewCard).not.toContainText("[\"English\"")
+
+    await page.getByRole("button", { name: "Accept" }).click()
+    await expect(page.getByText("Done. I applied that update to your resume. What would you like to improve next?")).toBeVisible()
+
+    await page.keyboard.press("Escape")
+    await expect(page.getByText("English")).toBeVisible()
+    await expect(page.getByText("Tagalog")).toBeVisible()
+  })
+
+  test("malformed structured list drafts fail safely without applying", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "grounded_suggestion",
+        reply: "I drafted updated languages for review.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "personalDetails",
+          itemId: null,
+          field: "knownLanguages",
+          scope: "resume_wide",
+        },
+        draft: {
+          summary: "Replace the languages list.",
+          proposedChanges: [
+            {
+              section: "personalDetails",
+              itemId: null,
+              field: "knownLanguages",
+              instruction: "Replace known languages with the reviewed list.",
+              proposedText: "[\"English\", 2]",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await page.getByRole("button", { name: "About you" }).click()
+    await openChatAssistant(page)
+
+    await page.getByRole("textbox", { name: "Message" }).fill("Update my languages.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await page.getByRole("button", { name: "Accept" }).click()
+
+    await expect(page.getByTestId("chat-inline-error")).toContainText("Languages")
+    await expect(page.getByText("Done. I applied that update to your resume. What would you like to improve next?")).toHaveCount(0)
+  })
+
+  test("accept applies a coreSkills create draft by adding a new local skill group", async ({ page }) => {
+    let requestCount = 0
+
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON()
+      expect(payload.activeDraft).toBeUndefined()
+      expect(payload.conversation).toBeUndefined()
+      expect(payload.conversationContext).toBeUndefined()
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "exact_edit",
+        reply: "I drafted a new Testing core skill group for review.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "coreSkills",
+          itemId: null,
+          field: null,
+          scope: "section",
+        },
+        draft: {
+          summary: "Create a new Testing core skill group.",
+          proposedChanges: [
+            {
+              section: "coreSkills",
+              itemId: null,
+              field: null,
+              instruction: "Create a new core skill group named Testing with the provided skills.",
+              proposedText: "{\"devLanguage\":\"Testing\",\"devFramework\":[\"Jest\",\"Playwright\",\"Jest\"]}",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await page.getByRole("button", { name: "Skill" }).click()
+    await expect(page.getByText("Untitled core skill")).toHaveCount(0)
+
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill("Create a Testing core skill group.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await expect(page.getByRole("button", { name: "Accept" })).toBeVisible()
+
+    await page.getByRole("button", { name: "Accept" }).click()
+
+    await expect(page.getByText("Done. I applied that update to your resume. What would you like to improve next?")).toBeVisible()
+    await expect(page.getByRole("button", { name: "Accept" })).toHaveCount(0)
+    await expect(page.getByRole("button", { name: "Reject" })).toHaveCount(0)
+    await expect(page.getByText("Create a new Testing core skill group.")).toHaveCount(0)
+
+    await page.keyboard.press("Escape")
+    await page.getByRole("button", { name: "Skill" }).click()
+    await expect(page.getByRole("button", { name: "Testing Jest, Playwright" })).toBeVisible()
+    expect(requestCount).toBe(1)
+  })
+
+  test("accept shows a user-safe inline error when a coreSkills create draft payload is malformed", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "exact_edit",
+        reply: "I drafted a new Testing core skill group for review.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "coreSkills",
+          itemId: null,
+          field: null,
+          scope: "section",
+        },
+        draft: {
+          summary: "Create a new Testing core skill group.",
+          proposedChanges: [
+            {
+              section: "coreSkills",
+              itemId: null,
+              field: null,
+              instruction: "Create a new core skill group named Testing with the provided skills.",
+              proposedText: "{\"devLanguage\":\"Testing\",\"devFramework\":\"Jest\"}",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await page.getByRole("button", { name: "Skill" }).click()
+    await openChatAssistant(page)
+
+    await page.getByRole("textbox", { name: "Message" }).fill("Create a Testing core skill group.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await page.getByRole("button", { name: "Accept" }).click()
+
+    await expect(page.getByTestId("chat-inline-error")).toContainText("The AI draft did not include a valid core skill group to create.")
+    await expect(page.getByText("Done. I applied that update to your resume. What would you like to improve next?")).toHaveCount(0)
+  })
+
+  test("accept blocks duplicate coreSkills group names with an inline error", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    let requestCount = 0
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "exact_edit",
+        reply: "I drafted a new Testing core skill group for review.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "coreSkills",
+          itemId: null,
+          field: null,
+          scope: "section",
+        },
+        draft: {
+          summary: "Create a new Testing core skill group.",
+          proposedChanges: [
+            {
+              section: "coreSkills",
+              itemId: null,
+              field: null,
+              instruction: "Create a new core skill group named Testing with the provided skills.",
+              proposedText: "{\"devLanguage\":\"Testing\",\"devFramework\":[\"Jest\",\"Playwright\"]}",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill("Create a Testing core skill group.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await page.getByRole("button", { name: "Accept" }).click()
+    await expect(page.getByText("Done. I applied that update to your resume. What would you like to improve next?")).toBeVisible()
+
+    await page.getByRole("textbox", { name: "Message" }).fill("Create a Testing core skill group again.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await page.getByRole("button", { name: "Accept" }).click()
+
+    await expect(page.getByTestId("chat-inline-error")).toContainText("A core skill group named Testing already exists in local data.")
+    await expect(page.getByText("Done. I applied that update to your resume. What would you like to improve next?")).toHaveCount(1)
+    expect(requestCount).toBe(2)
+  })
+
+  test("active-draft follow-ups send raw user text with recent conversation memory", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    let requestCount = 0
+    let projectId = ""
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON()
+
+      if (requestCount === 1) {
+        expect(payload.message).toBe("Add a Codex bullet to Kaizer.")
+        expect(payload.activeDraft).toBeUndefined()
+        expect(payload.conversation).toBeUndefined()
+        expect(payload.conversationContext).toBeUndefined()
+        expect(Array.isArray(payload.resumeData.personalProjects)).toBe(true)
+        expect(payload.resumeData.personalProjects).toHaveLength(1)
+
+        projectId = payload.resumeData.personalProjects[0].id
+        expect(projectId).toBeTruthy()
+        expect(payload.resumeData.personalProjects[0].projectName).toBe("Kaizer")
+
+        await fulfillJson(route, 200, {
+          provider: "pollination",
+          mode: "exact_edit",
+          reply: "I drafted a Kaizer bullet for review.",
+          status: "draft_ready",
+          clarificationQuestion: null,
+          needsClarification: false,
+          needsConfirmation: true,
+          readyToApply: false,
+          target: {
+            section: "personalProjects",
+            itemId: projectId,
+            field: "bulletSummary",
+            scope: "single_item",
+          },
+          draft: {
+            summary: "Add Codex usage bullet to Kaizer project.",
+            proposedChanges: [
+              {
+                section: "personalProjects",
+                itemId: projectId,
+                field: "bulletSummary",
+                instruction: "Add the new Codex-related bullet to Kaizer.",
+                proposedText: "Used Codex to support implementation, iteration, and development workflows during Kaizer development.",
+              },
+            ],
+          },
+          warnings: [],
+        })
+        return
+      }
+      expect(payload.message).toBe("Remove the phrase \"during Kaizer development.\"")
+      expect(payload.message).not.toContain("Revise the current draft")
+      expect(payload.message).not.toContain("Keep the same target and revise only this draft.")
+      expect(payload.activeDraft).toEqual({
+        mode: "exact_edit",
+        target: {
+          section: "personalProjects",
+          itemId: projectId,
+          field: "bulletSummary",
+          scope: "single_item",
+        },
+        draft: {
+          summary: "Add Codex usage bullet to Kaizer project.",
+          proposedChanges: [
+            {
+              section: "personalProjects",
+              itemId: projectId,
+              field: "bulletSummary",
+              instruction: "Add the new Codex-related bullet to Kaizer.",
+              proposedText: "Used Codex to support implementation, iteration, and development workflows during Kaizer development.",
+            },
+          ],
+        },
+      })
+      expect(payload.conversation).toEqual([
+        { role: "user", text: "Add a Codex bullet to Kaizer." },
+        { role: "assistant", text: "I drafted a Kaizer bullet for review." },
+      ])
+      expect(payload.conversationContext).toBeUndefined()
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "exact_edit",
+        reply: "I revised the draft and removed that phrase.",
+        status: "draft_ready",
+        clarificationQuestion: null,
+        needsClarification: false,
+        needsConfirmation: true,
+        readyToApply: false,
+        target: {
+          section: "personalProjects",
+          itemId: projectId,
+          field: "bulletSummary",
+          scope: "single_item",
+        },
+        draft: {
+          summary: "Revise the Kaizer Codex bullet.",
+          proposedChanges: [
+            {
+              section: "personalProjects",
+              itemId: projectId,
+              field: "bulletSummary",
+              instruction: "Revise the Kaizer Codex-related bullet.",
+              proposedText: "Used Codex to support implementation, iteration, and development workflows.",
+            },
+          ],
+        },
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await page.getByRole("button", { name: "Personal Project" }).click()
+    await page.getByRole("button", { name: "Add an item" }).click()
+    await page.getByLabel("Project name").fill("Kaizer")
+
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill("Add a Codex bullet to Kaizer.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await expect(page.getByRole("button", { name: "Accept" })).toBeVisible()
+
+    const followUpMessage = "Remove the phrase \"during Kaizer development.\""
+    await page.getByRole("textbox", { name: "Message" }).fill(followUpMessage)
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    await expect(page.locator(".chat-bubble").filter({ hasText: followUpMessage })).toBeVisible()
+    await expect(page.getByText("Revise the current draft for personalProjects > Kaizer > bulletSummary.")).toHaveCount(0)
+    await expect(page.getByText("I revised the draft and removed that phrase.")).toBeVisible()
+    expect(requestCount).toBe(2)
+  })
+
+  test("explicitly naming a different target sends raw user text with recent conversation memory", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+
+    let requestCount = 0
+    let novaId = ""
+    let kaizerId = ""
+
+    await page.route("**/v1/ai/chat", async (route) => {
+      requestCount += 1
+      const payload = route.request().postDataJSON()
+
+      if (requestCount === 1) {
+        expect(payload.message).toBe("Add a Codex bullet to Nova.")
+        expect(payload.activeDraft).toBeUndefined()
+        expect(payload.conversation).toBeUndefined()
+        expect(payload.conversationContext).toBeUndefined()
+
+        expect(Array.isArray(payload.resumeData.personalProjects)).toBe(true)
+        expect(payload.resumeData.personalProjects).toHaveLength(2)
+
+        novaId = payload.resumeData.personalProjects.find((item: { projectName: string }) => item.projectName === "Nova")?.id ?? ""
+        kaizerId = payload.resumeData.personalProjects.find((item: { projectName: string }) => item.projectName === "Kaizer")?.id ?? ""
+
+        expect(novaId).toBeTruthy()
+        expect(kaizerId).toBeTruthy()
+
+        await fulfillJson(route, 200, {
+          provider: "pollination",
+          mode: "exact_edit",
+          reply: "I drafted a Nova bullet for review.",
+          status: "draft_ready",
+          clarificationQuestion: null,
+          needsClarification: false,
+          needsConfirmation: true,
+          readyToApply: false,
+          target: {
+            section: "personalProjects",
+            itemId: novaId,
+            field: "bulletSummary",
+            scope: "single_item",
+          },
+          draft: {
+            summary: "Add Codex usage bullet to Nova project.",
+            proposedChanges: [
+              {
+                section: "personalProjects",
+                itemId: novaId,
+                field: "bulletSummary",
+                instruction: "Add the new Codex-related bullet to Nova.",
+                proposedText: "Used Codex to support Nova implementation and iteration.",
+              },
+            ],
+          },
+          warnings: [],
+        })
+        return
+      }
+      expect(payload.message).toBe("Update Kaizer instead.")
+      expect(payload.message).not.toContain("Revise the current draft for personalProjects > Nova > bulletSummary.")
+      expect(payload.message).not.toContain("Keep the same target and revise only this draft.")
+      expect(payload.activeDraft).toEqual({
+        mode: "exact_edit",
+        target: {
+          section: "personalProjects",
+          itemId: novaId,
+          field: "bulletSummary",
+          scope: "single_item",
+        },
+        draft: {
+          summary: "Add Codex usage bullet to Nova project.",
+          proposedChanges: [
+            {
+              section: "personalProjects",
+              itemId: novaId,
+              field: "bulletSummary",
+              instruction: "Add the new Codex-related bullet to Nova.",
+              proposedText: "Used Codex to support Nova implementation and iteration.",
+            },
+          ],
+        },
+      })
+      expect(payload.conversation).toEqual([
+        { role: "user", text: "Add a Codex bullet to Nova." },
+        { role: "assistant", text: "I drafted a Nova bullet for review." },
+      ])
+      expect(payload.conversationContext).toBeUndefined()
+
+      await fulfillJson(route, 200, {
+        provider: "pollination",
+        mode: "grounded_suggestion",
+        reply: "I can switch to Kaizer.",
+        status: "clarification_needed",
+        clarificationQuestion: "Which Kaizer bullet should I update?",
+        needsClarification: true,
+        needsConfirmation: false,
+        readyToApply: false,
+        target: {
+          section: "personalProjects",
+          itemId: kaizerId,
+          field: "bulletSummary",
+          scope: "single_item",
+        },
+        draft: null,
+        warnings: [],
+      })
+    })
+
+    await startEditor(page)
+    await page.getByRole("button", { name: "Personal Project" }).click()
+
+    await page.getByRole("button", { name: "Add an item" }).click()
+    await page.getByLabel("Project name").fill("Nova")
+
+    await page.getByRole("button", { name: "Add an item" }).click()
+    await page.getByLabel("Project name").fill("Kaizer")
+
+    await openChatAssistant(page)
+    await page.getByRole("textbox", { name: "Message" }).fill("Add a Codex bullet to Nova.")
+    await page.getByRole("button", { name: "Send message" }).click()
+    await expect(page.getByRole("button", { name: "Accept" })).toBeVisible()
+
+    const switchMessage = "Update Kaizer instead."
+    await page.getByRole("textbox", { name: "Message" }).fill(switchMessage)
+    await page.getByRole("button", { name: "Send message" }).click()
+
+    await expect(page.locator(".chat-bubble").filter({ hasText: switchMessage })).toBeVisible()
+    await expect(page.getByText("Which Kaizer bullet should I update?")).toBeVisible()
+    await expect(page.getByRole("button", { name: "Accept" })).toHaveCount(0)
+    await expect(page.getByRole("button", { name: "Reject" })).toHaveCount(0)
+    await expect(page.getByText("Revise the current draft for personalProjects > Nova > bulletSummary.")).toHaveCount(0)
+    expect(requestCount).toBe(2)
+  })
+})


### PR DESCRIPTION
## Logs

### Added

- Added the Chat Assistant with local conversation persistence, inline notices, loading states, clear-conversation confirmation, and local `Accept` / `Reject` draft controls.
- Added backend-aligned chat request handling for `activeDraft`, `pendingAction`, and `userDecision` while keeping draft acceptance local to the frontend.
- Added robust draft preview and local apply support for multi-item changes, section clears, item removal, text updates, bullet updates, and object creation across resume sections.
- Added Pollinations API key configuration with `sk_` / `pk_` validation and `Authorization: Bearer` submission when a valid key is configured.
- Added a Chat Assistant information dialog explaining beta behavior, Pollinations AI usage, and one-section-at-a-time guidance.
- Added a privacy/security notice explaining that resume data is stored locally in the browser, and that Chat Assistant requests send only the needed resume context to the AI service for response generation without storing that request data on this app's server.
- Added resume import replacement confirmation when existing resume data would be overwritten.

### Changed

- Refreshed Chat Assistant UI copy, header controls, composer actions, review-card layout, and draft action labels.
- Reworked draft preview formatting so all `draft.proposedChanges` entries render instead of only the first change.
- Improved editor visual consistency with Slate-style controls, glassmorphism panel treatment, clearer separators, and lighter Modify Components contrast.
- Updated form, upload, multiselect, reset, empty-list, and assistant waiting-state copy.
- Disabled resume JSON import controls while import is in progress.

### Fixed

- Fixed Chat Assistant local apply behavior for item creation, deletion, full-section clearing, empty-text field updates, bullet toggles, certificates, achievements, core skills, soft skills, and known languages.
- Fixed stale `activeDraft`, clarification, and pending confirmation state from leaking into unrelated follow-up chat requests.
- Fixed double-encoded JSON draft previews so certificate and other object drafts render friendly field rows instead of raw JSON text.
- Fixed repeated-entry sorting behavior for vertical drag-and-drop, including first-position drops, hidden expanded inputs while dragging, stable card colors, and removal of distracting drop-line highlights.
- Fixed editor focus-ring clipping and improved input contrast consistency across standard inputs, textareas, multiselects, and upload fields.